### PR TITLE
Support multi-proxy config for HTTP probes

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -122,7 +122,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.0.1)
     bindata (2.5.1)
-    brakeman (7.1.2)
+    brakeman (8.0.2)
       racc
     builder (3.3.0)
     cgi (0.5.1)
@@ -647,7 +647,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.0.1) sha256=8b07d3d065a9f921c80ceaea7c9d4ae596697295b584c296fe599dd0ad01c4a7
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
-  brakeman (7.1.2) sha256=6b04927710a2e7d13a72248b5d404c633188e02417f28f3d853e4b6370d26dce
+  brakeman (8.0.2) sha256=7b02065ce8b1de93949cefd3f2ad78e8eb370e644b95c8556a32a912a782426a
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab

--- a/app/models/upright/probes/http_probe.rb
+++ b/app/models/upright/probes/http_probe.rb
@@ -74,9 +74,13 @@ class Upright::Probes::HTTPProbe < FrozenRecord::Base
     end
 
     def proxy_credentials
-      if try(:proxy)
-        Rails.application.credentials.dig(:proxies, proxy.to_sym)
+      if selected_proxy
+        Rails.application.credentials.dig(:proxies, selected_proxy.to_sym)
       end
+    end
+
+    def selected_proxy
+      Array(try(:proxies) || try(:proxy)).sample
     end
 
     def record_response_status

--- a/test/dummy/probes/http_probes.yml
+++ b/test/dummy/probes/http_probes.yml
@@ -4,3 +4,10 @@
 - name: "Expected301"
   url: "https://example.com/redirect"
   expected_status: 301
+
+- name: "MultiProxy"
+  url: "https://example.com/multi"
+  proxies:
+    - proxy_a
+    - proxy_b
+    - proxy_c


### PR DESCRIPTION
Support multi-proxy config for HTTP probes

Will avoid total failure if one proxy is unavailable.