### PR TITLE
Add probe status dashboard

### DIFF
--- a/app/assets/stylesheets/upright/dashboard.css
+++ b/app/assets/stylesheets/upright/dashboard.css
@@ -295,6 +295,18 @@
     gap: 0.5em;
   }
 
+  .probe-status-probe-link {
+    align-items: center;
+    color: inherit;
+    display: flex;
+    gap: 0.5em;
+    text-decoration: none;
+  }
+
+  .probe-status-probe-link:hover {
+    text-decoration: underline;
+  }
+
   .probe-status-row--down {
     background: oklch(var(--lch-red-dark) / 8%);
   }

--- a/app/assets/stylesheets/upright/dashboard.css
+++ b/app/assets/stylesheets/upright/dashboard.css
@@ -257,6 +257,89 @@
     text-align: center;
   }
 
+  /* Probe Status Matrix */
+  .probe-status-wrapper {
+    background: oklch(var(--lch-ink-lightest) / 85%);
+    border-radius: 0.25rem;
+    box-shadow: var(--shadow);
+    overflow-x: auto;
+  }
+
+  .probe-status-table {
+    border-collapse: collapse;
+    box-shadow: none;
+    min-width: 100%;
+  }
+
+  .probe-status-table th,
+  .probe-status-table td {
+    border: 1px solid var(--color-ink-lighter);
+    font-size: var(--text-x-small);
+    padding: 0.5em 0.75em;
+    text-align: center;
+    white-space: nowrap;
+  }
+
+  .probe-status-probe-header,
+  .probe-status-probe {
+    background: var(--color-ink-lighter);
+    font-weight: 500;
+    left: 0;
+    position: sticky;
+    text-align: left;
+  }
+
+  .probe-status-probe {
+    display: flex;
+    align-items: center;
+    gap: 0.5em;
+  }
+
+  .probe-status-row--down {
+    background: oklch(var(--lch-red-dark) / 8%);
+  }
+
+  .probe-status-cell--up {
+    background: oklch(var(--lch-green-dark) / 10%);
+  }
+
+  .probe-status-cell--down {
+    background: oklch(var(--lch-red-dark) / 15%);
+  }
+
+  .probe-status-cell--stale {
+    background: oklch(75% 0.1 85 / 15%);
+  }
+
+  .probe-status-indicator {
+    font-weight: 600;
+    display: block;
+  }
+
+  .probe-status-indicator--up {
+    color: var(--color-positive);
+  }
+
+  .probe-status-indicator--down {
+    color: var(--color-negative);
+  }
+
+  .probe-status-indicator--stale {
+    color: oklch(75% 0.15 85);
+  }
+
+  .probe-status-indicator--unknown {
+    color: var(--color-ink-medium);
+  }
+
+  .probe-status-down-since {
+    color: var(--color-negative);
+    display: block;
+    font-size: calc(var(--text-x-small) * 0.85);
+    font-weight: 400;
+    margin-top: 0.15em;
+  }
+
   @media (max-width: 85ch) {
     .dashboard {
       padding: var(--block-space);

--- a/app/assets/stylesheets/upright/dashboard.css
+++ b/app/assets/stylesheets/upright/dashboard.css
@@ -307,6 +307,16 @@
     text-decoration: underline;
   }
 
+  .probe-status-cell-link {
+    color: inherit;
+    display: block;
+    text-decoration: none;
+  }
+
+  .probe-status-cell-link:hover {
+    opacity: 0.8;
+  }
+
   .probe-status-row--down {
     background: oklch(var(--lch-red-dark) / 8%);
   }

--- a/app/controllers/upright/dashboards/probe_statuses_controller.rb
+++ b/app/controllers/upright/dashboards/probe_statuses_controller.rb
@@ -1,0 +1,7 @@
+class Upright::Dashboards::ProbeStatusesController < Upright::ApplicationController
+  def show
+    @probe_type = params.fetch(:probe_type, :http)
+    @probes = Upright::Probes::Status.for_type(@probe_type)
+    @sites = Upright.sites
+  end
+end

--- a/app/helpers/upright/dashboards_helper.rb
+++ b/app/helpers/upright/dashboards_helper.rb
@@ -28,4 +28,16 @@ module Upright::DashboardsHelper
       mins.zero? ? "#{hours}h" : "#{hours}h #{mins}m"
     end
   end
+
+  def probe_status_css_class(status)
+    if status.nil?
+      "probe-status-cell--unknown"
+    elsif status.stale?
+      "probe-status-cell--stale"
+    elsif status.up?
+      "probe-status-cell--up"
+    else
+      "probe-status-cell--down"
+    end
+  end
 end

--- a/app/javascript/upright/controllers/auto_refresh_controller.js
+++ b/app/javascript/upright/controllers/auto_refresh_controller.js
@@ -4,42 +4,13 @@ export default class extends Controller {
   static values = { interval: { type: Number, default: 60000 } }
 
   connect() {
-    this.startRefreshing()
-    document.addEventListener("visibilitychange", this.handleVisibilityChange)
+    this.timer = setInterval(() => {
+      this.element.src = window.location.href
+      this.element.reload()
+    }, this.intervalValue)
   }
 
   disconnect() {
-    this.stopRefreshing()
-    document.removeEventListener("visibilitychange", this.handleVisibilityChange)
-  }
-
-  startRefreshing() {
-    this.timer = setInterval(() => this.refresh(), this.intervalValue)
-  }
-
-  stopRefreshing() {
-    if (this.timer) {
-      clearInterval(this.timer)
-      this.timer = null
-    }
-  }
-
-  refresh() {
-    if (this.element.tagName === "TURBO-FRAME" && this.element.src) {
-      this.element.reload()
-    } else if (this.element.tagName === "TURBO-FRAME") {
-      // Frame without explicit src reloads from current URL
-      this.element.src = window.location.href
-      this.element.reload()
-    }
-  }
-
-  handleVisibilityChange = () => {
-    if (document.hidden) {
-      this.stopRefreshing()
-    } else {
-      this.refresh()
-      this.startRefreshing()
-    }
+    clearInterval(this.timer)
   }
 }

--- a/app/javascript/upright/controllers/auto_refresh_controller.js
+++ b/app/javascript/upright/controllers/auto_refresh_controller.js
@@ -1,0 +1,45 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static values = { interval: { type: Number, default: 60000 } }
+
+  connect() {
+    this.startRefreshing()
+    document.addEventListener("visibilitychange", this.handleVisibilityChange)
+  }
+
+  disconnect() {
+    this.stopRefreshing()
+    document.removeEventListener("visibilitychange", this.handleVisibilityChange)
+  }
+
+  startRefreshing() {
+    this.timer = setInterval(() => this.refresh(), this.intervalValue)
+  }
+
+  stopRefreshing() {
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+  }
+
+  refresh() {
+    if (this.element.tagName === "TURBO-FRAME" && this.element.src) {
+      this.element.reload()
+    } else if (this.element.tagName === "TURBO-FRAME") {
+      // Frame without explicit src reloads from current URL
+      this.element.src = window.location.href
+      this.element.reload()
+    }
+  }
+
+  handleVisibilityChange = () => {
+    if (document.hidden) {
+      this.stopRefreshing()
+    } else {
+      this.refresh()
+      this.startRefreshing()
+    }
+  }
+}

--- a/app/models/upright/probes/status.rb
+++ b/app/models/upright/probes/status.rb
@@ -1,0 +1,58 @@
+class Upright::Probes::Status
+  class << self
+    def for_type(probe_type)
+      results = prometheus_client.query_range(
+        query: query(probe_type),
+        start: 15.minutes.ago.iso8601,
+        end:   Time.current.iso8601,
+        step:  "30s"
+      ).deep_symbolize_keys
+
+      build_probes(results[:result])
+    end
+
+    private
+      def query(probe_type)
+        "upright_probe_up#{label_selector(probe_type)}"
+      end
+
+      def label_selector(probe_type)
+        if probe_type.present?
+          "{type=\"#{probe_type}\"}"
+        end
+      end
+
+      def prometheus_client
+        Prometheus::ApiClient.client(
+          url: ENV.fetch("PROMETHEUS_URL", "http://localhost:9090"),
+          options: { timeout: 30.seconds }
+        )
+      end
+
+      def build_probes(results)
+        # Group results by probe identity (name + type + probe_target)
+        grouped = results.group_by { |r| [ r[:metric][:name], r[:metric][:type], r[:metric][:probe_target] ] }
+
+        grouped.map do |(_name, _type, _target), series|
+          site_statuses = series.map do |s|
+            SiteStatus.new(
+              site_code: s[:metric][:site],
+              site_city: site_city(s[:metric][:site]),
+              values: s[:values]
+            )
+          end
+
+          Probe.new(
+            name: _name,
+            type: _type,
+            probe_target: _target,
+            site_statuses: site_statuses
+          )
+        end.sort
+      end
+
+      def site_city(code)
+        Upright.find_site(code)&.city || code.to_s
+      end
+  end
+end

--- a/app/models/upright/probes/status/probe.rb
+++ b/app/models/upright/probes/status/probe.rb
@@ -1,0 +1,24 @@
+class Upright::Probes::Status::Probe
+  include Comparable
+
+  attr_reader :name, :type, :probe_target, :site_statuses
+
+  def initialize(name:, type:, probe_target:, site_statuses:)
+    @name = name
+    @type = type
+    @probe_target = probe_target
+    @site_statuses = site_statuses
+  end
+
+  def status_for_site(code)
+    site_statuses.find { |s| s.site_code == code.to_s }
+  end
+
+  def any_down?
+    site_statuses.any?(&:down?)
+  end
+
+  def <=>(other)
+    [ type, name ] <=> [ other.type, other.name ]
+  end
+end

--- a/app/models/upright/probes/status/probe.rb
+++ b/app/models/upright/probes/status/probe.rb
@@ -19,6 +19,6 @@ class Upright::Probes::Status::Probe
   end
 
   def <=>(other)
-    [ type, name ] <=> [ other.type, other.name ]
+    [ any_down? ? 0 : 1, type, name ] <=> [ other.any_down? ? 0 : 1, other.type, other.name ]
   end
 end

--- a/app/models/upright/probes/status/site_status.rb
+++ b/app/models/upright/probes/status/site_status.rb
@@ -1,0 +1,51 @@
+class Upright::Probes::Status::SiteStatus
+  STALE_THRESHOLD = 5.minutes
+
+  attr_reader :site_code, :site_city
+
+  def initialize(site_code:, site_city:, values:)
+    @site_code = site_code
+    @site_city = site_city
+    @values = values
+  end
+
+  def up?
+    latest_value == 1
+  end
+
+  def down?
+    !up?
+  end
+
+  def stale?
+    return true if @values.empty?
+    Time.at(latest_timestamp) < STALE_THRESHOLD.ago
+  end
+
+  def down_since
+    return nil unless down?
+    return nil if @values.empty?
+
+    # Walk backwards to find when the continuous run of 0s started
+    sorted = @values.sort_by(&:first)
+    down_start = sorted.last.first
+
+    sorted.reverse_each do |timestamp, value|
+      break if value.to_f == 1
+      down_start = timestamp
+    end
+
+    Time.at(down_start)
+  end
+
+  private
+    def latest_value
+      return nil if @values.empty?
+      @values.max_by(&:first).last.to_f
+    end
+
+    def latest_timestamp
+      return nil if @values.empty?
+      @values.max_by(&:first).first
+    end
+end

--- a/app/views/layouts/upright/_header.html.erb
+++ b/app/views/layouts/upright/_header.html.erb
@@ -9,6 +9,7 @@
   <nav class="header__nav">
     <%= link_to "Probes", upright.site_root_url(subdomain: current_or_default_site.code), class: "header__link" %>
     <%= link_to "Uptime", upright.dashboards_uptime_url(subdomain: Upright.configuration.global_subdomain), class: "header__link" %>
+    <%= link_to "Status", upright.dashboards_probe_status_url(subdomain: Upright.configuration.global_subdomain), class: "header__link" %>
     <span class="header__divider"></span>
     <%= link_to "Jobs", upright.jobs_url(subdomain: current_or_default_site.code), class: "header__link" %>
     <span class="header__divider"></span>

--- a/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
@@ -25,16 +25,18 @@
             <% sites.each do |site| %>
               <% status = probe.status_for_site(site.code) %>
               <td class="probe-status-cell <%= probe_status_css_class(status) %>">
-                <% if status.nil? %>
-                  <span class="probe-status-indicator probe-status-indicator--unknown">—</span>
-                <% elsif status.stale? %>
-                  <span class="probe-status-indicator probe-status-indicator--stale">STALE</span>
-                <% elsif status.up? %>
-                  <span class="probe-status-indicator probe-status-indicator--up">UP</span>
-                <% else %>
-                  <span class="probe-status-indicator probe-status-indicator--down">DOWN</span>
-                  <% if status.down_since %>
-                    <span class="probe-status-down-since"><%= time_ago_in_words(status.down_since) %> ago</span>
+                <%= link_to upright.site_root_url(subdomain: site.code, probe_type: probe.type, probe_name: probe.name), class: "probe-status-cell-link" do %>
+                  <% if status.nil? %>
+                    <span class="probe-status-indicator probe-status-indicator--unknown">—</span>
+                  <% elsif status.stale? %>
+                    <span class="probe-status-indicator probe-status-indicator--stale">STALE</span>
+                  <% elsif status.up? %>
+                    <span class="probe-status-indicator probe-status-indicator--up">UP</span>
+                  <% else %>
+                    <span class="probe-status-indicator probe-status-indicator--down">DOWN</span>
+                    <% if status.down_since %>
+                      <span class="probe-status-down-since"><%= time_ago_in_words(status.down_since) %> ago</span>
+                    <% end %>
                   <% end %>
                 <% end %>
               </td>

--- a/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
@@ -1,0 +1,45 @@
+<% if probes.empty? %>
+  <div class="no-data-message">
+    No probe data available for the selected type.
+  </div>
+<% else %>
+  <div class="probe-status-wrapper">
+    <table class="probe-status-table">
+      <thead>
+        <tr>
+          <th class="probe-status-probe-header">Probe</th>
+          <% sites.each do |site| %>
+            <th class="probe-status-site-header"><%= site.city %></th>
+          <% end %>
+        </tr>
+      </thead>
+      <tbody>
+        <% probes.each do |probe| %>
+          <tr class="<%= "probe-status-row--down" if probe.any_down? %>">
+            <td class="probe-status-probe">
+              <%= probe_type_icon(probe.type) %>
+              <span><%= probe.name %></span>
+            </td>
+            <% sites.each do |site| %>
+              <% status = probe.status_for_site(site.code) %>
+              <td class="probe-status-cell <%= probe_status_css_class(status) %>">
+                <% if status.nil? %>
+                  <span class="probe-status-indicator probe-status-indicator--unknown">—</span>
+                <% elsif status.stale? %>
+                  <span class="probe-status-indicator probe-status-indicator--stale">STALE</span>
+                <% elsif status.up? %>
+                  <span class="probe-status-indicator probe-status-indicator--up">UP</span>
+                <% else %>
+                  <span class="probe-status-indicator probe-status-indicator--down">DOWN</span>
+                  <% if status.down_since %>
+                    <span class="probe-status-down-since"><%= time_ago_in_words(status.down_since) %> ago</span>
+                  <% end %>
+                <% end %>
+              </td>
+            <% end %>
+          </tr>
+        <% end %>
+      </tbody>
+    </table>
+  </div>
+<% end %>

--- a/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
@@ -17,8 +17,10 @@
         <% probes.each do |probe| %>
           <tr class="<%= "probe-status-row--down" if probe.any_down? %>">
             <td class="probe-status-probe">
-              <%= probe_type_icon(probe.type) %>
-              <span><%= probe.name %></span>
+              <%= link_to upright.site_root_url(subdomain: Upright.sites.first.code, probe_type: probe.type, probe_name: probe.name), class: "probe-status-probe-link" do %>
+                <%= probe_type_icon(probe.type) %>
+                <span><%= probe.name %></span>
+              <% end %>
             </td>
             <% sites.each do |site| %>
               <% status = probe.status_for_site(site.code) %>

--- a/app/views/upright/dashboards/probe_statuses/show.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/show.html.erb
@@ -1,0 +1,17 @@
+<div class="dashboard probe-status-dashboard">
+  <header class="dashboard-header">
+    <h1>Probe Status</h1>
+
+    <div class="dashboard-filters">
+      <%= form_with url: dashboards_probe_status_path, method: :get, data: { controller: "form", turbo_frame: :probe_status_matrix } do %>
+        <%= collection_select nil, :probe_type, Upright::Probeable::TYPES, :itself, :titleize,
+              { selected: @probe_type },
+              { class: "input--select", data: { action: "change->form#submit" } } %>
+      <% end %>
+    </div>
+  </header>
+
+  <turbo-frame id="probe_status_matrix" data-controller="auto-refresh" data-auto-refresh-interval-value="60000">
+    <%= render "matrix", probes: @probes, sites: @sites %>
+  </turbo-frame>
+</div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,6 +10,7 @@ Upright::Engine.routes.draw do
 
     namespace :dashboards do
       resource :uptime, only: :show
+      resource :probe_status, only: :show
     end
 
     scope :framed do

--- a/test/dummy/bin/setup
+++ b/test/dummy/bin/setup
@@ -20,6 +20,9 @@ FileUtils.chdir APP_ROOT do
   #   FileUtils.cp "config/database.yml.sample", "config/database.yml"
   # end
 
+  puts "\n== Starting services =="
+  system! "bin/services"
+
   puts "\n== Preparing database =="
   system! "bin/rails db:prepare"
   system! "bin/rails db:reset" if ARGV.include?("--reset")

--- a/test/integration/dashboards/probe_statuses_controller_test.rb
+++ b/test/integration/dashboards/probe_statuses_controller_test.rb
@@ -1,0 +1,34 @@
+require "test_helper"
+
+class Upright::Dashboards::ProbeStatusesControllerTest < ActionDispatch::IntegrationTest
+  test "shows probe status dashboard" do
+    on_subdomain "app"
+    sign_in
+    stub_prometheus_query_range([])
+
+    get upright.dashboards_probe_status_path
+
+    assert_response :success
+  end
+
+  test "filters by probe type" do
+    on_subdomain "app"
+    sign_in
+    stub_prometheus_query_range([
+      { "metric" => { "name" => "example.com", "type" => "http", "probe_target" => "https://example.com", "site" => "iad" },
+        "values" => [ [ 2.minutes.ago.to_i, "1" ] ] }
+    ])
+
+    get upright.dashboards_probe_status_path(probe_type: "http")
+
+    assert_response :success
+  end
+
+  private
+    def stub_prometheus_query_range(result)
+      response = { status: "success", data: { resultType: "matrix", result: result } }
+
+      stub_request(:get, /localhost:9090.*query_range/)
+        .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+    end
+end

--- a/test/models/upright/probes/status/site_status_test.rb
+++ b/test/models/upright/probes/status/site_status_test.rb
@@ -1,0 +1,101 @@
+require "test_helper"
+
+class Upright::Probes::Status::SiteStatusTest < ActiveSupport::TestCase
+  test "up? returns true when latest value is 1" do
+    status = build_status(values: [
+      [ 5.minutes.ago.to_i, "1" ],
+      [ 2.minutes.ago.to_i, "1" ]
+    ])
+
+    assert status.up?
+    assert_not status.down?
+  end
+
+  test "down? returns true when latest value is 0" do
+    status = build_status(values: [
+      [ 5.minutes.ago.to_i, "1" ],
+      [ 2.minutes.ago.to_i, "0" ]
+    ])
+
+    assert status.down?
+    assert_not status.up?
+  end
+
+  test "down_since finds when continuous downtime started" do
+    t1 = 10.minutes.ago.to_i
+    t2 = 8.minutes.ago.to_i
+    t3 = 6.minutes.ago.to_i
+    t4 = 4.minutes.ago.to_i
+    t5 = 2.minutes.ago.to_i
+
+    status = build_status(values: [
+      [ t1, "1" ],
+      [ t2, "1" ],
+      [ t3, "0" ],
+      [ t4, "0" ],
+      [ t5, "0" ]
+    ])
+
+    assert_equal Time.at(t3), status.down_since
+  end
+
+  test "down_since returns earliest timestamp when all values are 0" do
+    t1 = 10.minutes.ago.to_i
+    t2 = 5.minutes.ago.to_i
+    t3 = 2.minutes.ago.to_i
+
+    status = build_status(values: [
+      [ t1, "0" ],
+      [ t2, "0" ],
+      [ t3, "0" ]
+    ])
+
+    assert_equal Time.at(t1), status.down_since
+  end
+
+  test "down_since returns nil when up" do
+    status = build_status(values: [
+      [ 2.minutes.ago.to_i, "1" ]
+    ])
+
+    assert_nil status.down_since
+  end
+
+  test "stale? returns true when latest data point is older than 5 minutes" do
+    status = build_status(values: [
+      [ 10.minutes.ago.to_i, "1" ]
+    ])
+
+    assert status.stale?
+  end
+
+  test "stale? returns false when latest data point is recent" do
+    status = build_status(values: [
+      [ 2.minutes.ago.to_i, "1" ]
+    ])
+
+    assert_not status.stale?
+  end
+
+  test "stale? returns true when values are empty" do
+    status = build_status(values: [])
+
+    assert status.stale?
+  end
+
+  test "exposes site_code and site_city" do
+    status = build_status(site_code: "iad", site_city: "Ashburn")
+
+    assert_equal "iad", status.site_code
+    assert_equal "Ashburn", status.site_city
+  end
+
+  private
+    def build_status(site_code: "iad", site_city: "Ashburn", values: [])
+      Upright::Probes::Status::SiteStatus.new(
+        site_code: site_code,
+        site_city: site_city,
+        values: values
+      )
+    end
+end

--- a/test/models/upright/probes/status_test.rb
+++ b/test/models/upright/probes/status_test.rb
@@ -1,0 +1,51 @@
+require "test_helper"
+
+class Upright::Probes::StatusTest < ActiveSupport::TestCase
+  test ".for_type returns sorted Probe objects grouped by probe identity" do
+    stub_prometheus_query_range([
+      { "metric" => { "name" => "zebra.com", "type" => "http", "probe_target" => "https://zebra.com", "site" => "iad" },
+        "values" => [ [ 2.minutes.ago.to_i, "1" ] ] },
+      { "metric" => { "name" => "zebra.com", "type" => "http", "probe_target" => "https://zebra.com", "site" => "ams" },
+        "values" => [ [ 2.minutes.ago.to_i, "1" ] ] },
+      { "metric" => { "name" => "alpha.com", "type" => "http", "probe_target" => "https://alpha.com", "site" => "iad" },
+        "values" => [ [ 2.minutes.ago.to_i, "0" ] ] }
+    ])
+
+    probes = Upright::Probes::Status.for_type(:http)
+
+    assert_equal 2, probes.size
+    assert_equal "alpha.com", probes.first.name
+    assert_equal "zebra.com", probes.last.name
+    assert_equal 2, probes.last.site_statuses.size
+  end
+
+  test ".for_type returns empty array when no results" do
+    stub_prometheus_query_range([])
+
+    assert_equal [], Upright::Probes::Status.for_type(:http)
+  end
+
+  test "probe exposes site statuses with up/down state" do
+    stub_prometheus_query_range([
+      { "metric" => { "name" => "example.com", "type" => "http", "probe_target" => "https://example.com", "site" => "iad" },
+        "values" => [ [ 2.minutes.ago.to_i, "1" ] ] },
+      { "metric" => { "name" => "example.com", "type" => "http", "probe_target" => "https://example.com", "site" => "ams" },
+        "values" => [ [ 2.minutes.ago.to_i, "0" ] ] }
+    ])
+
+    probes = Upright::Probes::Status.for_type(:http)
+    probe = probes.first
+
+    assert probe.any_down?
+    assert probe.status_for_site("iad").up?
+    assert probe.status_for_site("ams").down?
+  end
+
+  private
+    def stub_prometheus_query_range(result)
+      response = { status: "success", data: { resultType: "matrix", result: result } }
+
+      stub_request(:get, /localhost:9090.*query_range/)
+        .to_return(status: 200, body: response.to_json, headers: { "Content-Type" => "application/json" })
+    end
+end


### PR DESCRIPTION
Real-time matrix view of probe UP/DOWN state per site, querying the upright_probe_up metric from Prometheus. Includes auto-refresh (60s), probe type filtering, and down-since timestamps.