### PR TITLE
Add flag emojis to site names in the UI

### DIFF
--- a/app/helpers/upright/application_helper.rb
+++ b/app/helpers/upright/application_helper.rb
@@ -3,9 +3,19 @@ module Upright::ApplicationHelper
     Upright::Current.site || Upright.sites.first
   end
 
+  def site_name(site)
+    "#{country_flag(site.country)} #{site.city}"
+  end
+
   def upright_stylesheet_link_tag(**options)
     Upright::Engine.root.join("app/assets/stylesheets/upright").glob("*.css")
       .map { |f| "upright/#{f.basename('.css')}" }.sort
       .then { |stylesheets| stylesheet_link_tag(*stylesheets, **options) }
+  end
+
+  private
+
+  def country_flag(country_code)
+    country_code&.upcase&.gsub(/[A-Z]/) { |c| (c.ord + 0x1F1A5).chr(Encoding::UTF_8) }
   end
 end

--- a/app/views/layouts/upright/_header.html.erb
+++ b/app/views/layouts/upright/_header.html.erb
@@ -2,7 +2,7 @@
   <div class="header__left">
     <%= link_to "Upright", root_url(subdomain: Upright.configuration.global_subdomain), class: "header__logo" %>
     <% if Upright::Current.site.present? %>
-      <span class="header__site"><%= Upright::Current.site.city %></span>
+      <span class="header__site"><%= site_name(Upright::Current.site) %></span>
     <% end %>
   </div>
 

--- a/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/_matrix.html.erb
@@ -9,7 +9,7 @@
         <tr>
           <th class="probe-status-probe-header">Probe</th>
           <% sites.each do |site| %>
-            <th class="probe-status-site-header"><%= site.city %></th>
+            <th class="probe-status-site-header"><%= site_name(site) %></th>
           <% end %>
         </tr>
       </thead>

--- a/app/views/upright/sites/index.html.erb
+++ b/app/views/upright/sites/index.html.erb
@@ -14,7 +14,7 @@
       <% @sites.each do |site| %>
         <tr>
           <td><%= link_to site.host, site.url %></td>
-          <td><%= site.city %></td>
+          <td><%= site_name(site) %></td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
## Summary
- Add a `site_name` helper that converts ISO country codes to flag emojis (e.g., "NL" → 🇳🇱) and prepends them to city names
- Use the helper in the header, sites index table, and probe status matrix column headers

## Test plan
- [ ] Visit the sites index page and confirm flags appear in the table
- [ ] Visit the probe status dashboard and confirm flags appear in column headers
- [ ] Navigate to a site-specific page and confirm the flag appears in the header

🤖 Generated with [Claude Code](https://claude.com/claude-code)