### PR TITLE
Fix Alertmanager proxy dropping request body on POST

### DIFF
--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -5,7 +5,7 @@ class Upright::AlertmanagerProxyController < Upright::ApplicationController
   end
 
   def proxy
-    proxy_to_alertmanager request.fullpath.delete_prefix("/alertmanager")
+    proxy_to_alertmanager request.fullpath.delete_prefix("/alertmanager"), body: request.body&.read
   end
 
   private

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -15,4 +15,18 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  test "proxies POST body to alertmanager" do
+    silence_json = { matchers: [ { name: "alertname", value: "TestAlert", isRegex: false, isEqual: true } ], comment: "test" }.to_json
+
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+      .with(body: silence_json)
+      .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
+
+    sign_in
+    post "/alertmanager/api/v2/silences", params: silence_json, headers: { "Content-Type" => "application/json" }
+
+    assert_response :success
+    assert_requested stub
+  end
 end


### PR DESCRIPTION
## Summary
- The Alertmanager proxy controller wasn't forwarding the request body to Alertmanager, so POST requests (like creating silences) arrived empty and failed
- Pass `request.body&.read` through to the Faraday request

## Test plan
- [x] Added integration test verifying POST body is forwarded to Alertmanager
- [ ] Create a silence via the Alertmanager UI in production