### PR TITLE
Fix Playwright timeout not capturing video

### DIFF
--- a/app/models/concerns/upright/playwright/lifecycle.rb
+++ b/app/models/concerns/upright/playwright/lifecycle.rb
@@ -33,8 +33,9 @@ module Upright::Playwright::Lifecycle
       run_callbacks :page_ready
       yield
     ensure
-      page&.close
-      context&.close
+      # Rescue each step independently so a failed close doesn't prevent video capture
+      page&.close rescue Rails.error.report($!)
+      context&.close rescue Rails.error.report($!)
       run_callbacks :page_close
     end
 


### PR DESCRIPTION
## Summary
- When `page.close` raises during cleanup (e.g. browser disconnected after a timeout), the remaining ensure steps — `context.close` and the `save_video` callback — were skipped entirely, losing the video recording
- Rescue each cleanup step independently so video capture always runs

## Test plan
- [x] Existing Playwright probe tests pass
- [ ] Deploy and verify that timed-out probes now have video artifacts attached

🤖 Generated with [Claude Code](https://claude.com/claude-code)