### PR TITLE
Add optional alert_severity to probes

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,11 +172,14 @@ Add probes to `probes/http_probes.yml`:
 - name: API Health
   url: https://api.example.com/health
   expected_status: 200
+  alert_severity: critical
 
 - name: Admin Panel
   url: https://admin.example.com
   basic_auth_credentials: admin_auth  # Key in Rails credentials
 ```
+
+The optional `alert_severity` field controls the Prometheus alert severity when a probe fails. Values: `medium`, `high` (default), `critical`.
 
 ### SMTP Probes
 
@@ -407,7 +410,7 @@ groups:
         expr: upright_probe_up == 0
         for: 5m
         labels:
-          severity: critical
+          severity: "{{ $labels.alert_severity }}"
         annotations:
           summary: "Probe {{ $labels.name }} is down"
 ```

--- a/app/models/concerns/upright/probeable.rb
+++ b/app/models/concerns/upright/probeable.rb
@@ -3,6 +3,7 @@ module Upright::Probeable
   include Upright::Staggerable
 
   TYPES = %w[ http playwright smtp traceroute ]
+  ALERT_SEVERITIES = %i[ medium high critical ]
 
   included do
     attr_writer :logger
@@ -35,6 +36,7 @@ module Upright::Probeable
       probe_name: probe_name,
       probe_target: probe_target,
       probe_service: probe_service,
+      probe_alert_severity: probe_alert_severity,
       status: result[:status],
       duration: result[:duration],
       error: result[:error]
@@ -61,6 +63,11 @@ module Upright::Probeable
 
   def probe_service
     nil
+  end
+
+  def probe_alert_severity
+    severity = try(:alert_severity)&.to_sym
+    ALERT_SEVERITIES.include?(severity) ? severity : :high
   end
 
   private

--- a/app/models/upright/probe_result.rb
+++ b/app/models/upright/probe_result.rb
@@ -1,6 +1,8 @@
 class Upright::ProbeResult < Upright::ApplicationRecord
   include Upright::ExceptionRecording
 
+  attr_accessor :probe_alert_severity
+
   has_many_attached :artifacts
 
   scope :by_type,   ->(type) { where(probe_type: type) if type.present? }
@@ -23,7 +25,7 @@ class Upright::ProbeResult < Upright::ApplicationRecord
 
   private
     def increment_metrics
-      labels = { type: probe_type, name: probe_name, probe_target: probe_target, probe_service: probe_service }
+      labels = { type: probe_type, name: probe_name, probe_target: probe_target, probe_service: probe_service, alert_severity: probe_alert_severity || :high }
 
       Yabeda.upright_probe_duration_seconds.set(labels.merge(status: status), duration.to_f)
       Yabeda.upright_probe_up.set(labels, ok? ? 1 : 0)

--- a/lib/generators/upright/install/templates/http_probes.yml
+++ b/lib/generators/upright/install/templates/http_probes.yml
@@ -7,6 +7,7 @@
 #
 # Optional fields:
 #   - expected_status: HTTP status code to expect (default: 200-399)
+#   - alert_severity: Alert severity when probe fails: medium, high (default), critical
 #   - basic_auth_credentials: Key in Rails credentials for basic auth
 #   - proxy: Key in Rails credentials for proxy settings
 

--- a/lib/generators/upright/install/templates/smtp_probes.yml
+++ b/lib/generators/upright/install/templates/smtp_probes.yml
@@ -4,6 +4,9 @@
 # Required fields:
 #   - name: Unique identifier for the probe
 #   - host: SMTP server hostname
+#
+# Optional fields:
+#   - alert_severity: Alert severity when probe fails: medium, high (default), critical
 
 # - name: Example Mail Server
 #   host: mail.example.com

--- a/lib/generators/upright/install/templates/traceroute_probes.yml
+++ b/lib/generators/upright/install/templates/traceroute_probes.yml
@@ -4,6 +4,9 @@
 # Required fields:
 #   - name: Unique identifier for the probe
 #   - host: Hostname or IP address to trace
+#
+# Optional fields:
+#   - alert_severity: Alert severity when probe fails: medium, high (default), critical
 
 # - name: Example Service
 #   host: example.com

--- a/lib/generators/upright/install/templates/upright.rules.yml
+++ b/lib/generators/upright/install/templates/upright.rules.yml
@@ -8,9 +8,9 @@ groups:
       # Fraction of regions reporting DOWN (0.0 to 1.0)
       - record: upright:probe_down_fraction
         expr: |
-          count by (name, type, probe_target) (upright_probe_up == 0)
+          count by (name, type, probe_target, alert_severity) (upright_probe_up == 0)
           /
-          count by (name, type, probe_target) (upright_probe_up)
+          count by (name, type, probe_target, alert_severity) (upright_probe_up)
 
       # Daily uptime percentage (0.0 to 1.0)
       # Uptime = percentage of time in past day when majority of sites reported UP
@@ -148,7 +148,7 @@ groups:
           upright: "https://app.<%= app_domain %>/?probe_type={{ $labels.type }}&status=fail&probe_name={{ $labels.name | urlquery }}"
         expr: upright:probe_down_fraction{type="http"} > 0.5
         labels:
-          severity: page
+          severity: "{{ $labels.alert_severity }}"
           group: upright
 
       - alert: UprightHTTPProbeDegraded
@@ -187,7 +187,7 @@ groups:
           upright: "https://app.<%= app_domain %>/?probe_type={{ $labels.type }}&status=fail&probe_name={{ $labels.name | urlquery }}"
         expr: upright:probe_down_fraction{type="smtp"} > 0.5
         labels:
-          severity: page
+          severity: "{{ $labels.alert_severity }}"
           group: upright
 
       - alert: UprightSMTPProbeDegraded
@@ -226,7 +226,7 @@ groups:
           upright: "https://app.<%= app_domain %>/?probe_type={{ $labels.type }}&status=fail&probe_name={{ $labels.name | urlquery }}"
         expr: upright:probe_down_fraction{type="playwright"} > 0.5
         labels:
-          severity: page
+          severity: "{{ $labels.alert_severity }}"
           group: upright
 
       - alert: UprightPlaywrightProbeDegraded

--- a/lib/upright/metrics.rb
+++ b/lib/upright/metrics.rb
@@ -44,12 +44,12 @@ module Upright::Metrics
             gauge :probe_duration_seconds,
               comment: "Duration of each probe",
               aggregation: :max,
-              tags: %i[type name probe_target probe_service status]
+              tags: %i[type name probe_target probe_service alert_severity status]
 
             gauge :probe_up,
               comment: "Probe status (1 = up, 0 = down)",
               aggregation: :most_recent,
-              tags: %i[type name probe_target probe_service]
+              tags: %i[type name probe_target probe_service alert_severity]
 
             gauge :http_response_status,
               comment: "HTTP response status code",

--- a/test/dummy/bin/seed-prometheus
+++ b/test/dummy/bin/seed-prometheus
@@ -92,7 +92,7 @@ echo "Generating seed data..."
           val=0
         fi
 
-        echo "upright_probe_up{name=\"${pname}\",type=\"${ptype}\",probe_target=\"${ptarget}\",probe_service=\"\",site_code=\"${scode}\",site_city=\"${scity}\",site_country=\"${scountry}\",site_geohash=\"${sgeohash}\",site_provider=\"${sprovider}\"} ${val}.0 ${ts}.0"
+        echo "upright_probe_up{name=\"${pname}\",type=\"${ptype}\",probe_target=\"${ptarget}\",probe_service=\"\",alert_severity=\"high\",site_code=\"${scode}\",site_city=\"${scity}\",site_country=\"${scountry}\",site_geohash=\"${sgeohash}\",site_provider=\"${sprovider}\"} ${val}.0 ${ts}.0"
       done
     done
   done

--- a/test/dummy/config/prometheus/rules/upright.yml
+++ b/test/dummy/config/prometheus/rules/upright.yml
@@ -7,9 +7,9 @@ groups:
       # Fraction of regions reporting DOWN (0.0 to 1.0)
       - record: upright:probe_down_fraction
         expr: |
-          count by (name, type, probe_target) (upright_probe_up == 0)
+          count by (name, type, probe_target, alert_severity) (upright_probe_up == 0)
           /
-          count by (name, type, probe_target) (upright_probe_up)
+          count by (name, type, probe_target, alert_severity) (upright_probe_up)
 
       # Daily uptime percentage (0.0 to 1.0)
       # Uptime = percentage of time in past day when majority of sites reported UP

--- a/test/dummy/probes/http_probes.yml
+++ b/test/dummy/probes/http_probes.yml
@@ -11,3 +11,19 @@
     - proxy_a
     - proxy_b
     - proxy_c
+
+- name: "MediumSeverity"
+  url: "https://example.com/medium"
+  alert_severity: medium
+
+- name: "HighSeverity"
+  url: "https://example.com/high"
+  alert_severity: high
+
+- name: "CriticalSeverity"
+  url: "https://example.com/critical"
+  alert_severity: critical
+
+- name: "InvalidSeverity"
+  url: "https://example.com/invalid"
+  alert_severity: unknown

--- a/test/models/upright/concerns/probeable_test.rb
+++ b/test/models/upright/concerns/probeable_test.rb
@@ -1,0 +1,71 @@
+require "test_helper"
+
+class Upright::ProbeableTest < ActiveSupport::TestCase
+  # Minimal probe that includes Probeable without a YAML source,
+  # so alert_severity is not defined by default (simulates missing field).
+  class MinimalProbe
+    include Upright::Probeable
+
+    def probe_type = "test"
+    def probe_target = "test"
+    def on_check_recorded(_) = nil
+  end
+
+  # Probe with a fixed alert_severity method (e.g. a Playwright-style override).
+  class ProbeWithSeverityMethod < MinimalProbe
+    def alert_severity = "critical"
+  end
+
+  class ProbeWithInvalidSeverityMethod < MinimalProbe
+    def alert_severity = "urgent"
+  end
+
+  # --- default behaviour ---
+
+  test "defaults to :high when alert_severity is not defined" do
+    probe = MinimalProbe.new
+    assert_equal :high, probe.probe_alert_severity
+  end
+
+  test "defaults to :high when alert_severity is nil" do
+    probe = MinimalProbe.new
+    probe.stubs(:alert_severity).returns(nil)
+    assert_equal :high, probe.probe_alert_severity
+  end
+
+  # --- valid values from YAML (FrozenRecord-based probes) ---
+
+  test "returns :medium when alert_severity is set to medium in YAML" do
+    probe = Upright::Probes::HTTPProbe.find_by(name: "MediumSeverity")
+    assert_equal :medium, probe.probe_alert_severity
+  end
+
+  test "returns :high when alert_severity is set to high in YAML" do
+    probe = Upright::Probes::HTTPProbe.find_by(name: "HighSeverity")
+    assert_equal :high, probe.probe_alert_severity
+  end
+
+  test "returns :critical when alert_severity is set to critical in YAML" do
+    probe = Upright::Probes::HTTPProbe.find_by(name: "CriticalSeverity")
+    assert_equal :critical, probe.probe_alert_severity
+  end
+
+  # --- invalid values from YAML fall back to :high ---
+
+  test "falls back to :high for an unrecognised alert_severity in YAML" do
+    probe = Upright::Probes::HTTPProbe.find_by(name: "InvalidSeverity")
+    assert_equal :high, probe.probe_alert_severity
+  end
+
+  # --- valid/invalid values from method overrides (e.g. Playwright probes) ---
+
+  test "returns :critical when alert_severity method returns a valid value" do
+    probe = ProbeWithSeverityMethod.new
+    assert_equal :critical, probe.probe_alert_severity
+  end
+
+  test "falls back to :high when alert_severity method returns an invalid value" do
+    probe = ProbeWithInvalidSeverityMethod.new
+    assert_equal :high, probe.probe_alert_severity
+  end
+end

--- a/test/models/upright/concerns/probeable_test.rb
+++ b/test/models/upright/concerns/probeable_test.rb
@@ -1,8 +1,6 @@
 require "test_helper"
 
 class Upright::ProbeableTest < ActiveSupport::TestCase
-  # Minimal probe that includes Probeable without a YAML source,
-  # so alert_severity is not defined by default (simulates missing field).
   class MinimalProbe
     include Upright::Probeable
 
@@ -11,7 +9,6 @@ class Upright::ProbeableTest < ActiveSupport::TestCase
     def on_check_recorded(_) = nil
   end
 
-  # Probe with a fixed alert_severity method (e.g. a Playwright-style override).
   class ProbeWithSeverityMethod < MinimalProbe
     def alert_severity = "critical"
   end
@@ -19,8 +16,6 @@ class Upright::ProbeableTest < ActiveSupport::TestCase
   class ProbeWithInvalidSeverityMethod < MinimalProbe
     def alert_severity = "urgent"
   end
-
-  # --- default behaviour ---
 
   test "defaults to :high when alert_severity is not defined" do
     probe = MinimalProbe.new
@@ -32,8 +27,6 @@ class Upright::ProbeableTest < ActiveSupport::TestCase
     probe.stubs(:alert_severity).returns(nil)
     assert_equal :high, probe.probe_alert_severity
   end
-
-  # --- valid values from YAML (FrozenRecord-based probes) ---
 
   test "returns :medium when alert_severity is set to medium in YAML" do
     probe = Upright::Probes::HTTPProbe.find_by(name: "MediumSeverity")
@@ -50,14 +43,10 @@ class Upright::ProbeableTest < ActiveSupport::TestCase
     assert_equal :critical, probe.probe_alert_severity
   end
 
-  # --- invalid values from YAML fall back to :high ---
-
   test "falls back to :high for an unrecognised alert_severity in YAML" do
     probe = Upright::Probes::HTTPProbe.find_by(name: "InvalidSeverity")
     assert_equal :high, probe.probe_alert_severity
   end
-
-  # --- valid/invalid values from method overrides (e.g. Playwright probes) ---
 
   test "returns :critical when alert_severity method returns a valid value" do
     probe = ProbeWithSeverityMethod.new


### PR DESCRIPTION
## Summary

- Probes can now specify `alert_severity: medium | high | critical` (default: `high`) to control the Prometheus alert severity when a probe fails
- YAML probes set it in the YAML file, Playwright probes override `def alert_severity`
- The severity is exposed as an `alert_severity` label on `upright_probe_up` and `upright_probe_duration_seconds` metrics
- Recording rule `upright:probe_down_fraction` preserves the label, and probe-down alert rules use `severity: "{{ $labels.alert_severity }}"`

## Usage

**YAML probes:**
```yaml
- name: API Health
  url: https://api.example.com/health
  alert_severity: critical
```

**Playwright probes:**
```ruby
class Probes::Playwright::MyProbe < Upright::Probes::Playwright::Base
  def alert_severity = :critical
end
```

## Deploy notes

The new `alert_severity` metric label will appear on all probe metrics after deploy. Existing alert rules that use static `severity` labels should be updated to use `severity: "{{ $labels.alert_severity }}"` on probe-down alerts.