### PR TITLE
Aggregate away alert_severity in uptime query to fix duplicate rows

### DIFF
--- a/app/models/upright/probes/uptime.rb
+++ b/app/models/upright/probes/uptime.rb
@@ -17,7 +17,7 @@ class Upright::Probes::Uptime
 
     private
       def query(probe_type)
-        "upright:probe_uptime_daily#{label_selector(probe_type)}"
+        "min by (name, type, probe_target) (upright:probe_uptime_daily#{label_selector(probe_type)})"
       end
 
       def label_selector(probe_type)


### PR DESCRIPTION
The uptime recording rule now carries alert_severity, and stale series from before the label change are still within the 1-day lookback window, producing up to 3 series per probe. Use min by (name, type, probe_target) to collapse them into one row per probe on the uptime page.