### PR TITLE
Retain probe failures beyond 24 hours, 30 days or 1000

### DIFF
--- a/app/models/concerns/upright/probe_result/stale_cleanup.rb
+++ b/app/models/concerns/upright/probe_result/stale_cleanup.rb
@@ -21,7 +21,7 @@ module Upright::ProbeResult::StaleCleanup
         fail.order(created_at: :desc).offset(FAILURE_RETENTION_LIMIT).pick(:created_at)
       ].compact.max
 
-      fail.where(created_at: ...cutoff).in_batches.destroy_all
+      fail.where(created_at: ..cutoff).in_batches.destroy_all
     end
   end
 end

--- a/app/models/concerns/upright/probe_result/stale_cleanup.rb
+++ b/app/models/concerns/upright/probe_result/stale_cleanup.rb
@@ -1,0 +1,27 @@
+module Upright::ProbeResult::StaleCleanup
+  extend ActiveSupport::Concern
+
+  STALE_SUCCESS_THRESHOLD = 24.hours
+  STALE_FAILURE_THRESHOLD = 30.days
+  FAILURE_RETENTION_LIMIT = 1000
+
+  class_methods do
+    def cleanup_stale
+      cleanup_stale_successes
+      cleanup_stale_failures
+    end
+
+    def cleanup_stale_successes
+      ok.where(created_at: ...STALE_SUCCESS_THRESHOLD.ago).in_batches.destroy_all
+    end
+
+    def cleanup_stale_failures
+      cutoff = [
+        STALE_FAILURE_THRESHOLD.ago,
+        fail.order(created_at: :desc).offset(FAILURE_RETENTION_LIMIT).pick(:created_at)
+      ].compact.max
+
+      fail.where(created_at: ...cutoff).in_batches.destroy_all
+    end
+  end
+end

--- a/app/models/upright/probe_result.rb
+++ b/app/models/upright/probe_result.rb
@@ -1,5 +1,6 @@
 class Upright::ProbeResult < Upright::ApplicationRecord
   include Upright::ExceptionRecording
+  include Upright::ProbeResult::StaleCleanup
 
   attr_accessor :probe_alert_severity
 

--- a/app/models/upright/probe_result.rb
+++ b/app/models/upright/probe_result.rb
@@ -9,7 +9,6 @@ class Upright::ProbeResult < Upright::ApplicationRecord
   scope :by_type,   ->(type) { where(probe_type: type) if type.present? }
   scope :by_status, ->(status) { where(status: status) if status.present? }
   scope :by_name,   ->(name) { where(probe_name: name) if name.present? }
-  scope :stale,     -> { where(created_at: ...24.hours.ago) }
 
   enum :status, [ :ok, :fail ]
 

--- a/lib/generators/upright/install/templates/recurring.yml
+++ b/lib/generators/upright/install/templates/recurring.yml
@@ -21,5 +21,5 @@ production:
     schedule: every hour at minute 12
 
   cleanup_stale_probe_results:
-    command: "Upright::ProbeResult.stale.in_batches.destroy_all"
+    command: "Upright::ProbeResult.cleanup_stale"
     schedule: every hour at minute 30

--- a/test/dummy/config/recurring.yml
+++ b/test/dummy/config/recurring.yml
@@ -29,5 +29,5 @@ production:
     schedule: every hour at minute 12
 
   cleanup_stale_probe_results:
-    command: "Upright::ProbeResult.stale.in_batches.destroy_all"
+    command: "Upright::ProbeResult.cleanup_stale"
     schedule: every hour at minute 30

--- a/test/fixtures/upright_probe_results.yml
+++ b/test/fixtures/upright_probe_results.yml
@@ -67,3 +67,27 @@ playwright_probe_result_without_artifacts:
   status: "ok"
   created_at: <%= Time.current %>
   updated_at: <%= Time.current %>
+
+stale_success:
+  probe_type: http
+  probe_name: HTTP Probe
+  duration: 0.1
+  status: "ok"
+  created_at: <%= 2.days.ago %>
+  updated_at: <%= 2.days.ago %>
+
+stale_failure:
+  probe_type: http
+  probe_name: HTTP Probe
+  duration: 0.1
+  status: "fail"
+  created_at: <%= 31.days.ago %>
+  updated_at: <%= 31.days.ago %>
+
+recent_failure:
+  probe_type: http
+  probe_name: HTTP Probe
+  duration: 0.1
+  status: "fail"
+  created_at: <%= 5.days.ago %>
+  updated_at: <%= 5.days.ago %>

--- a/test/integration/probe_results_controller_test.rb
+++ b/test/integration/probe_results_controller_test.rb
@@ -60,7 +60,7 @@ class ProbeResultsControllerTest < ActionDispatch::IntegrationTest
     chart_data = JSON.parse(css_select("[data-probe-results-chart-results-value]").first["data-probe-results-chart-results-value"])
 
     assert chart_data.all? { |r| r["status"] == "fail" }
-    assert_equal 2, chart_data.length
+    assert_equal 4, chart_data.length
   end
 
   test "paginates results when there are many" do

--- a/test/models/upright/probe_result_test.rb
+++ b/test/models/upright/probe_result_test.rb
@@ -26,4 +26,29 @@ class Upright::ProbeResultTest < ActiveSupport::TestCase
     assert_includes report, "app/models/foo.rb:10"
     assert_includes report, "app/controllers/bar.rb:5"
   end
+
+  test ".cleanup_stale removes old successes but keeps recent failures" do
+    stale_success_id = upright_probe_results(:stale_success).id
+    fresh_success_id = upright_probe_results(:http_probe_result).id
+    stale_failure_id = upright_probe_results(:stale_failure).id
+    recent_failure_id = upright_probe_results(:recent_failure).id
+
+    Upright::ProbeResult.cleanup_stale
+
+    assert_not Upright::ProbeResult.exists?(stale_success_id)
+    assert Upright::ProbeResult.exists?(fresh_success_id)
+    assert_not Upright::ProbeResult.exists?(stale_failure_id)
+    assert Upright::ProbeResult.exists?(recent_failure_id)
+  end
+
+  test ".cleanup_stale caps failures at retention limit" do
+    recent_failure_id = upright_probe_results(:recent_failure).id
+
+    stub_const(Upright::ProbeResult::StaleCleanup, :FAILURE_RETENTION_LIMIT, 2) do
+      Upright::ProbeResult.cleanup_stale
+
+      assert_not Upright::ProbeResult.exists?(recent_failure_id)
+      assert_equal 2, Upright::ProbeResult.fail.count
+    end
+  end
 end


### PR DESCRIPTION
Given that failures should be less likely than successes we should retain results for longer so that we can troubleshoot after the fact.