### PR TITLE
Clickable uptime days - filter probe results by date

### DIFF
--- a/app/assets/stylesheets/upright/uptime-bars.css
+++ b/app/assets/stylesheets/upright/uptime-bars.css
@@ -40,12 +40,21 @@
   /* Individual uptime bar */
   .uptime-bar {
     border-radius: 2px;
-    cursor: default;
     flex: 1;
     height: 24px;
     max-width: 12px;
     min-width: 4px;
     transition: transform 100ms, filter 100ms;
+  }
+
+  a.uptime-bar {
+    cursor: pointer;
+    display: block;
+    text-decoration: none;
+  }
+
+  div.uptime-bar {
+    cursor: default;
   }
 
   .uptime-bar:hover {

--- a/app/controllers/upright/probe_results_controller.rb
+++ b/app/controllers/upright/probe_results_controller.rb
@@ -12,6 +12,7 @@ class Upright::ProbeResultsController < Upright::ApplicationController
         .by_type(params[:probe_type])
         .by_status(params[:status])
         .by_name(params[:probe_name])
+        .by_date(params[:date])
         .with_attached_artifacts
     end
 end

--- a/app/helpers/upright/probe_results_helper.rb
+++ b/app/helpers/upright/probe_results_helper.rb
@@ -44,6 +44,7 @@ module Upright::ProbeResultsHelper
     parts << "for #{params[:probe_type].titleize} probes" if params[:probe_type].present?
     parts << "named #{params[:probe_name]}" if params[:probe_name].present?
     parts << "with status #{params[:status]}" if params[:status].present?
+    parts << "on #{Date.parse(params[:date]).to_fs(:long)}" if params[:date].present?
     parts.join(" ")
   end
 end

--- a/app/models/upright/probe_result.rb
+++ b/app/models/upright/probe_result.rb
@@ -8,6 +8,8 @@ class Upright::ProbeResult < Upright::ApplicationRecord
   scope :by_type,   ->(type) { where(probe_type: type) if type.present? }
   scope :by_status, ->(status) { where(status: status) if status.present? }
   scope :by_name,   ->(name) { where(probe_name: name) if name.present? }
+  scope :by_date,   ->(date) { where(created_at: Date.parse(date).all_day) if date.present? }
+
   scope :stale,     -> { where(created_at: ...24.hours.ago) }
 
   enum :status, [ :ok, :fail ]

--- a/app/views/upright/dashboards/_uptime_probe_row.html.erb
+++ b/app/views/upright/dashboards/_uptime_probe_row.html.erb
@@ -1,5 +1,5 @@
 <div class="data-table__row uptime-bars__row">
-  <%= link_to upright.site_root_url(subdomain: Upright.sites.first.code, probe_type: probe.type, probe_name: probe.name), class: "data-table__probe" do %>
+  <%= link_to upright.site_root_url(subdomain: current_or_default_site.code, probe_type: probe.type, probe_name: probe.name), class: "data-table__probe" do %>
     <%= probe_type_icon(probe.type) %>
     <span class="data-table__probe-name"><%= probe.name %></span>
   <% end %>
@@ -11,8 +11,9 @@
       <% else %>
         <% uptime_percent = uptime * 100 %>
         <% downtime_minutes = ((1 - uptime) * 24 * 60).round %>
-        <div class="uptime-bar uptime-bar--<%= uptime_label(uptime_percent) %>"
-             title="<%= uptime_bar_tooltip(date, uptime_percent, downtime_minutes) %>"></div>
+        <%= link_to upright.site_root_url(subdomain: current_or_default_site.code, probe_type: probe.type, probe_name: probe.name, date: date.iso8601),
+              class: "uptime-bar uptime-bar--#{uptime_label(uptime_percent)}",
+              title: uptime_bar_tooltip(date, uptime_percent, downtime_minutes) %>
       <% end %>
     <% end %>
   </div>

--- a/app/views/upright/probe_results/index.html.erb
+++ b/app/views/upright/probe_results/index.html.erb
@@ -16,6 +16,7 @@
     <div class="filters">
       <%= form_with url: site_root_path, method: :get, data: { controller: "form" } do |f| %>
         <%= hidden_field_tag :probe_type, params[:probe_type] if params[:probe_type].present? %>
+        <%= hidden_field_tag :date, params[:date] if params[:date].present? %>
         <label for="probe_name">Name</label>
         <%= select_tag :probe_name,
               options_for_select([["All", ""]] + @probe_names, params[:probe_name]),
@@ -26,6 +27,9 @@
               options_for_select([["All", ""]] + Upright::ProbeResult.statuses.keys.map { |s| [s.titleize, s] }, params[:status]),
               class: "input--select",
               data: { action: "change->form#submit" } %>
+        <% if params[:date].present? %>
+          <%= link_to "Clear date filter", site_root_path(probe_type: params[:probe_type], probe_name: params[:probe_name], status: params[:status]), class: "filter-clear" %>
+        <% end %>
       <% end %>
     </div>
 

--- a/test/integration/probe_results_controller_test.rb
+++ b/test/integration/probe_results_controller_test.rb
@@ -84,6 +84,13 @@ class ProbeResultsControllerTest < ActionDispatch::IntegrationTest
     assert_select "a.pagination__next[href*='probe_type=http']"
   end
 
+  test "filters by date" do
+    get upright.site_root_path(date: Date.current.iso8601)
+    assert_response :success
+    assert_select "p", text: /on #{Date.current.to_fs(:long)}/
+    assert_select "a.filter-clear", text: /Clear date filter/
+  end
+
   test "renders artifacts for probe results with attachments" do
     result = upright_probe_results(:http_probe_result)
     assert result.artifacts.attached?, "Test fixture should have attached artifact"


### PR DESCRIPTION
Supports jumping from downtime on the uptime page to specific failure logs.