### PR TITLE
Make probe result stale cleanup configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,18 @@ Upright.configure do |config|
 end
 ```
 
+### Probe Result Cleanup
+
+Upright automatically cleans up old probe results on a recurring schedule. You can configure the retention thresholds:
+
+```ruby
+Upright.configure do |config|
+  config.stale_success_threshold = 24.hours     # Delete successful results older than this (default: 24 hours)
+  config.stale_failure_threshold = 30.days       # Delete failed results older than this (default: 30 days)
+  config.failure_retention_limit = 20_000        # Keep at most this many failed results (default: 20,000)
+end
+```
+
 ## Defining Probes
 
 ### HTTP Probes

--- a/app/models/concerns/upright/probe_result/stale_cleanup.rb
+++ b/app/models/concerns/upright/probe_result/stale_cleanup.rb
@@ -1,10 +1,6 @@
 module Upright::ProbeResult::StaleCleanup
   extend ActiveSupport::Concern
 
-  STALE_SUCCESS_THRESHOLD = 24.hours
-  STALE_FAILURE_THRESHOLD = 30.days
-  FAILURE_RETENTION_LIMIT = 1000
-
   class_methods do
     def cleanup_stale
       cleanup_stale_successes
@@ -12,13 +8,13 @@ module Upright::ProbeResult::StaleCleanup
     end
 
     def cleanup_stale_successes
-      ok.where(created_at: ...STALE_SUCCESS_THRESHOLD.ago).in_batches.destroy_all
+      ok.where(created_at: ...Upright.config.stale_success_threshold.ago).in_batches.destroy_all
     end
 
     def cleanup_stale_failures
       cutoff = [
-        STALE_FAILURE_THRESHOLD.ago,
-        fail.order(created_at: :desc).offset(FAILURE_RETENTION_LIMIT).pick(:created_at)
+        Upright.config.stale_failure_threshold.ago,
+        fail.order(created_at: :desc).offset(Upright.config.failure_retention_limit).pick(:created_at)
       ].compact.max
 
       fail.where(created_at: ..cutoff).in_batches.destroy_all

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -29,6 +29,11 @@ class Upright::Configuration
   attr_accessor :prometheus_url
   attr_accessor :alert_webhook_url
 
+  # Probe result cleanup
+  attr_accessor :stale_success_threshold
+  attr_accessor :stale_failure_threshold
+  attr_accessor :failure_retention_limit
+
   def initialize
     @service_name = "upright"
     @user_agent = "Upright/1.0"
@@ -46,6 +51,10 @@ class Upright::Configuration
 
     @auth_provider = :static_credentials
     @auth_options = {}
+
+    @stale_success_threshold = 24.hours
+    @stale_failure_threshold = 30.days
+    @failure_retention_limit = 20_000
   end
 
   def global_subdomain

--- a/test/models/upright/probe_result_test.rb
+++ b/test/models/upright/probe_result_test.rb
@@ -44,11 +44,13 @@ class Upright::ProbeResultTest < ActiveSupport::TestCase
   test ".cleanup_stale caps failures at retention limit" do
     recent_failure_id = upright_probe_results(:recent_failure).id
 
-    stub_const(Upright::ProbeResult::StaleCleanup, :FAILURE_RETENTION_LIMIT, 2) do
-      Upright::ProbeResult.cleanup_stale
+    original = Upright.config.failure_retention_limit
+    Upright.config.failure_retention_limit = 2
+    Upright::ProbeResult.cleanup_stale
 
-      assert_not Upright::ProbeResult.exists?(recent_failure_id)
-      assert_equal 2, Upright::ProbeResult.fail.count
-    end
+    assert_not Upright::ProbeResult.exists?(recent_failure_id)
+    assert_equal 2, Upright::ProbeResult.fail.count
+  ensure
+    Upright.config.failure_retention_limit = original
   end
 end


### PR DESCRIPTION
## Summary
- Moves hardcoded stale cleanup constants (`STALE_SUCCESS_THRESHOLD`, `STALE_FAILURE_THRESHOLD`, `FAILURE_RETENTION_LIMIT`) into `Upright.config` so host apps can tune retention
- Bumps default `failure_retention_limit` from 1,000 to 20,000
- Documents the new config options in the README

## Test plan
- [ ] Existing `cleanup_stale` tests pass
- [ ] Verify config values are respected by setting custom thresholds in an initializer