### PR TITLE
Allow host apps to register custom probe types

### DIFF
--- a/README.md
+++ b/README.md
@@ -170,6 +170,79 @@ Upright.configure do |config|
 end
 ```
 
+## Custom Probe Types
+
+Upright ships with four built-in probe types: HTTP, Playwright, SMTP, and Traceroute. You can register your own to extend the system.
+
+### 1. Register the type
+
+Add it to your initializer so Upright knows about its name and icon:
+
+```ruby
+# config/initializers/upright.rb
+Upright.configure do |config|
+  config.probe_types.register :ping, name: "Ping", icon: "📶"
+end
+```
+
+### 2. Create the probe class
+
+Add a Ruby class in your `probes/` directory that extends `FrozenRecord::Base` and includes `Upright::Probeable` and `Upright::ProbeYamlSource`. Implement `probe_type`, `probe_target`, `check`, and `on_check_recorded`:
+
+```ruby
+# probes/ping_probe.rb
+class PingProbe < FrozenRecord::Base
+  include Upright::Probeable
+  include Upright::ProbeYamlSource
+
+  stagger_by_site 3.seconds
+
+  def check
+    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", host)
+    status.success?
+  end
+
+  def on_check_recorded(probe_result)
+    if @ping_output.present?
+      Upright::Artifact.new(name: "ping.log", content: @ping_output).attach_to(probe_result)
+    end
+  end
+
+  def probe_type = "ping"
+  def probe_target = host
+end
+```
+
+The `check` method should return a truthy value on success and a falsy value on failure.
+
+### 3. Define probes in YAML
+
+Create a YAML file matching the class name (e.g., `PingProbe` → `probes/ping_probes.yml`):
+
+```yaml
+# probes/ping_probes.yml
+- name: "Cloudflare DNS"
+  host: "1.1.1.1"
+
+- name: "Google DNS"
+  host: "8.8.8.8"
+```
+
+Fields defined in the YAML are available as methods on the probe instance (e.g., `host`).
+
+### 4. Schedule it
+
+Add a recurring job in `config/recurring.yml`:
+
+```yaml
+production:
+  ping_probes:
+    command: "PingProbe.check_and_record_all_later"
+    schedule: every 30 seconds
+```
+
+The custom type will automatically appear in all dashboard dropdowns and filter links.
+
 ## Defining Probes
 
 ### HTTP Probes

--- a/app/helpers/upright/probe_results_helper.rb
+++ b/app/helpers/upright/probe_results_helper.rb
@@ -1,6 +1,6 @@
 module Upright::ProbeResultsHelper
   def probe_type_icon(probe_type)
-    registered = Upright.probe_type_registry.find(probe_type)
+    registered = Upright.probe_types.find(probe_type)
     content_tag(:span, registered.icon, title: registered.name)
   end
 

--- a/app/helpers/upright/probe_results_helper.rb
+++ b/app/helpers/upright/probe_results_helper.rb
@@ -1,15 +1,8 @@
 module Upright::ProbeResultsHelper
-  PROBE_TYPE_ICONS = {
-    http: "🌐",
-    playwright: "🎭",
-    ping: "📶",
-    smtp: "✉️",
-    traceroute: "🛤️"
-  }
-
   def probe_type_icon(probe_type)
-    icon = PROBE_TYPE_ICONS.fetch(probe_type.to_s.downcase.to_sym)
-    content_tag(:span, icon, title: probe_type.titleize)
+    registered = Upright.probe_type_registry.find(probe_type)
+    icon = registered&.icon || "❓"
+    content_tag(:span, icon, title: registered&.name || probe_type.to_s.titleize)
   end
 
   def type_filter_link(label, probe_type = nil)

--- a/app/helpers/upright/probe_results_helper.rb
+++ b/app/helpers/upright/probe_results_helper.rb
@@ -1,8 +1,7 @@
 module Upright::ProbeResultsHelper
   def probe_type_icon(probe_type)
     registered = Upright.probe_type_registry.find(probe_type)
-    icon = registered&.icon || "❓"
-    content_tag(:span, icon, title: registered&.name || probe_type.to_s.titleize)
+    content_tag(:span, registered.icon, title: registered.name)
   end
 
   def type_filter_link(label, probe_type = nil)

--- a/app/models/concerns/upright/probeable.rb
+++ b/app/models/concerns/upright/probeable.rb
@@ -2,7 +2,6 @@ module Upright::Probeable
   extend ActiveSupport::Concern
   include Upright::Staggerable
 
-  TYPES = %w[ http playwright smtp traceroute ]
   ALERT_SEVERITIES = %i[ medium high critical ]
 
   included do

--- a/app/views/upright/dashboards/probe_statuses/show.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/show.html.erb
@@ -4,7 +4,7 @@
 
     <div class="dashboard-filters">
       <%= form_with url: dashboards_probe_status_path, method: :get, data: { controller: "form", turbo_frame: :probe_status_matrix } do %>
-        <%= collection_select nil, :probe_type, Upright::Probeable::TYPES, :itself, :titleize,
+        <%= collection_select nil, :probe_type, Upright.probe_type_registry, :type, :name,
               { selected: @probe_type },
               { class: "input--select", data: { action: "change->form#submit" } } %>
       <% end %>

--- a/app/views/upright/dashboards/probe_statuses/show.html.erb
+++ b/app/views/upright/dashboards/probe_statuses/show.html.erb
@@ -4,7 +4,7 @@
 
     <div class="dashboard-filters">
       <%= form_with url: dashboards_probe_status_path, method: :get, data: { controller: "form", turbo_frame: :probe_status_matrix } do %>
-        <%= collection_select nil, :probe_type, Upright.probe_type_registry, :type, :name,
+        <%= collection_select nil, :probe_type, Upright.probe_types, :type, :name,
               { selected: @probe_type },
               { class: "input--select", data: { action: "change->form#submit" } } %>
       <% end %>

--- a/app/views/upright/dashboards/uptimes/show.html.erb
+++ b/app/views/upright/dashboards/uptimes/show.html.erb
@@ -4,7 +4,7 @@
 
     <div class="dashboard-filters">
       <%= form_with url: dashboards_uptime_path, method: :get, data: { controller: "form", turbo_frame: :uptime_bars } do %>
-        <%= collection_select nil, :probe_type, Upright::Probeable::TYPES, :itself, :titleize,
+        <%= collection_select nil, :probe_type, Upright.probe_type_registry, :type, :name,
               { selected: @probe_type },
               { class: "input--select", data: { action: "change->form#submit" } } %>
       <% end %>

--- a/app/views/upright/dashboards/uptimes/show.html.erb
+++ b/app/views/upright/dashboards/uptimes/show.html.erb
@@ -4,7 +4,7 @@
 
     <div class="dashboard-filters">
       <%= form_with url: dashboards_uptime_path, method: :get, data: { controller: "form", turbo_frame: :uptime_bars } do %>
-        <%= collection_select nil, :probe_type, Upright.probe_type_registry, :type, :name,
+        <%= collection_select nil, :probe_type, Upright.probe_types, :type, :name,
               { selected: @probe_type },
               { class: "input--select", data: { action: "change->form#submit" } } %>
       <% end %>

--- a/app/views/upright/probe_results/index.html.erb
+++ b/app/views/upright/probe_results/index.html.erb
@@ -2,10 +2,9 @@
   <aside>
     <ul>
       <li><%= type_filter_link "All" %></li>
-      <li><%= type_filter_link "HTTP", "http" %></li>
-      <li><%= type_filter_link "Playwright", "playwright" %></li>
-      <li><%= type_filter_link "SMTP", "smtp" %></li>
-      <li><%= type_filter_link "Traceroute", "traceroute" %></li>
+      <% Upright.probe_type_registry.each do |probe_type| %>
+        <li><%= type_filter_link probe_type.name, probe_type.type %></li>
+      <% end %>
     </ul>
   </aside>
 

--- a/app/views/upright/probe_results/index.html.erb
+++ b/app/views/upright/probe_results/index.html.erb
@@ -2,7 +2,7 @@
   <aside>
     <ul>
       <li><%= type_filter_link "All" %></li>
-      <% Upright.probe_type_registry.each do |probe_type| %>
+      <% Upright.probe_types.each do |probe_type| %>
         <li><%= type_filter_link probe_type.name, probe_type.type %></li>
       <% end %>
     </ul>

--- a/lib/generators/upright/install/templates/upright.rb
+++ b/lib/generators/upright/install/templates/upright.rb
@@ -19,3 +19,6 @@ Upright.configure do |config|
   #   client_secret: ENV["OIDC_CLIENT_SECRET"]
   # }
 end
+
+# Register custom probe types (built-in types: http, playwright, smtp, traceroute)
+# Upright.register_probe_type :ftp_file, name: "FTP File", icon: "📂"

--- a/lib/generators/upright/install/templates/upright.rb
+++ b/lib/generators/upright/install/templates/upright.rb
@@ -18,7 +18,7 @@ Upright.configure do |config|
   #   client_id: ENV["OIDC_CLIENT_ID"],
   #   client_secret: ENV["OIDC_CLIENT_SECRET"]
   # }
-end
 
-# Register custom probe types (built-in types: http, playwright, smtp, traceroute)
-# Upright.register_probe_type :ftp_file, name: "FTP File", icon: "📂"
+  # Register custom probe types (built-in types: http, playwright, smtp, traceroute)
+  # config.probe_types.register :ftp_file, name: "FTP File", icon: "📂"
+end

--- a/lib/upright.rb
+++ b/lib/upright.rb
@@ -19,6 +19,7 @@ require "yabeda/puma/plugin"
 
 require "upright/version"
 require "upright/configuration"
+require "upright/probe_type_registry"
 require "upright/geohash"
 require "upright/site"
 require "upright/metrics"
@@ -36,6 +37,18 @@ module Upright
 
     def configure
       yield(configuration)
+    end
+
+    def probe_type_registry
+      @probe_type_registry ||= ProbeTypeRegistry.new
+    end
+
+    def register_probe_type(type, name:, icon:)
+      probe_type_registry.register(type, name:, icon:)
+    end
+
+    def probe_types
+      probe_type_registry.types
     end
 
     def sites

--- a/lib/upright.rb
+++ b/lib/upright.rb
@@ -39,16 +39,8 @@ module Upright
       yield(configuration)
     end
 
-    def probe_type_registry
-      @probe_type_registry ||= ProbeTypeRegistry.new
-    end
-
-    def register_probe_type(type, name:, icon:)
-      probe_type_registry.register(type, name:, icon:)
-    end
-
     def probe_types
-      probe_type_registry.types
+      configuration.probe_types
     end
 
     def sites

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -29,6 +29,9 @@ class Upright::Configuration
   attr_accessor :prometheus_url
   attr_accessor :alert_webhook_url
 
+  # Probe types
+  attr_reader :probe_types
+
   # Probe result cleanup
   attr_accessor :stale_success_threshold
   attr_accessor :stale_failure_threshold
@@ -45,6 +48,8 @@ class Upright::Configuration
     @frozen_record_path = nil
     @probes_path = nil
     @authenticators_path = nil
+
+    @probe_types = Upright::ProbeTypeRegistry.new
 
     @playwright_server_url = ENV["PLAYWRIGHT_SERVER_URL"]
     @otel_endpoint = ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -57,10 +57,10 @@ class Upright::Engine < ::Rails::Engine
   end
 
   initializer "upright.probe_types", before: :load_config_initializers do
-    Upright.register_probe_type :http, name: "HTTP", icon: "🌐"
-    Upright.register_probe_type :playwright, name: "Playwright", icon: "🎭"
-    Upright.register_probe_type :smtp, name: "SMTP", icon: "✉️"
-    Upright.register_probe_type :traceroute, name: "Traceroute", icon: "🛤️"
+    Upright.config.probe_types.register :http, name: "HTTP", icon: "🌐"
+    Upright.config.probe_types.register :playwright, name: "Playwright", icon: "🎭"
+    Upright.config.probe_types.register :smtp, name: "SMTP", icon: "✉️"
+    Upright.config.probe_types.register :traceroute, name: "Traceroute", icon: "🛤️"
   end
 
   initializer "upright.frozen_record" do

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -56,6 +56,13 @@ class Upright::Engine < ::Rails::Engine
     end
   end
 
+  initializer "upright.probe_types", before: :load_config_initializers do
+    Upright.register_probe_type :http, name: "HTTP", icon: "🌐"
+    Upright.register_probe_type :playwright, name: "Playwright", icon: "🎭"
+    Upright.register_probe_type :smtp, name: "SMTP", icon: "✉️"
+    Upright.register_probe_type :traceroute, name: "Traceroute", icon: "🛤️"
+  end
+
   initializer "upright.frozen_record" do
     FrozenRecord::Base.base_path = Upright.configuration.frozen_record_path
   end

--- a/lib/upright/probe_type_registry.rb
+++ b/lib/upright/probe_type_registry.rb
@@ -1,0 +1,29 @@
+module Upright
+  class ProbeTypeRegistry
+    ProbeType = Data.define(:type, :name, :icon)
+
+    include Enumerable
+
+    def initialize
+      @probe_types = []
+    end
+
+    def register(type, name:, icon:)
+      type = type.to_s
+      @probe_types.reject! { |pt| pt.type == type }
+      @probe_types << ProbeType.new(type:, name:, icon:)
+    end
+
+    def types
+      @probe_types.map(&:type)
+    end
+
+    def find(type)
+      @probe_types.find { |pt| pt.type == type.to_s }
+    end
+
+    def each(&block)
+      @probe_types.each(&block)
+    end
+  end
+end

--- a/lib/upright/probe_type_registry.rb
+++ b/lib/upright/probe_type_registry.rb
@@ -22,6 +22,10 @@ module Upright
       @probe_types.find { |pt| pt.type == type.to_s }
     end
 
+    def unregister(type)
+      @probe_types.reject! { |pt| pt.type == type.to_s }
+    end
+
     def each(&block)
       @probe_types.each(&block)
     end

--- a/test/dummy/config/initializers/upright.rb
+++ b/test/dummy/config/initializers/upright.rb
@@ -2,4 +2,6 @@ Upright.configure do |config|
   config.hostname = "upright.localhost"
   config.user_agent = "Upright-Test/1.0"
   config.auth_provider = :static_credentials
+
+  config.probe_types.register :ping, name: "Ping", icon: "📶"
 end

--- a/test/dummy/probes/ping_probe.rb
+++ b/test/dummy/probes/ping_probe.rb
@@ -1,0 +1,20 @@
+class PingProbe < FrozenRecord::Base
+  include Upright::Probeable
+  include Upright::ProbeYamlSource
+
+  stagger_by_site 3.seconds
+
+  def check
+    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", host)
+    status.success?
+  end
+
+  def on_check_recorded(probe_result)
+    if @ping_output.present?
+      Upright::Artifact.new(name: "ping.log", content: @ping_output).attach_to(probe_result)
+    end
+  end
+
+  def probe_type = "ping"
+  def probe_target = host
+end

--- a/test/dummy/probes/ping_probes.yml
+++ b/test/dummy/probes/ping_probes.yml
@@ -1,0 +1,5 @@
+- name: "Cloudflare DNS"
+  host: "1.1.1.1"
+
+- name: "Google DNS"
+  host: "8.8.8.8"

--- a/test/integration/probe_results_controller_test.rb
+++ b/test/integration/probe_results_controller_test.rb
@@ -11,6 +11,15 @@ class ProbeResultsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "renders filter links for all registered probe types" do
+    get upright.site_root_path
+    assert_response :success
+
+    Upright.probe_types.each do |probe_type|
+      assert_select "aside a[href*='probe_type=#{probe_type.type}']", text: /#{probe_type.name}/
+    end
+  end
+
   test "filters by probe type when signed in" do
     get upright.site_root_path(probe_type: "playwright")
     assert_response :success

--- a/test/lib/upright/probe_type_registry_test.rb
+++ b/test/lib/upright/probe_type_registry_test.rb
@@ -1,0 +1,64 @@
+require "test_helper"
+
+class Upright::ProbeTypeRegistryTest < ActiveSupport::TestCase
+  setup do
+    @registry = Upright::ProbeTypeRegistry.new
+  end
+
+  test "register adds a probe type" do
+    @registry.register(:ftp_file, name: "FTP File", icon: "📂")
+
+    assert_equal %w[ftp_file], @registry.types
+  end
+
+  test "register replaces an existing probe type with the same identifier" do
+    @registry.register(:http, name: "HTTP", icon: "🌐")
+    @registry.register(:http, name: "Custom HTTP", icon: "🔗")
+
+    assert_equal %w[http], @registry.types
+    assert_equal "Custom HTTP", @registry.find(:http).name
+    assert_equal "🔗", @registry.find(:http).icon
+  end
+
+  test "register accepts string or symbol type identifiers" do
+    @registry.register("ftp_file", name: "FTP File", icon: "📂")
+
+    assert_equal "FTP File", @registry.find(:ftp_file).name
+    assert_equal "FTP File", @registry.find("ftp_file").name
+  end
+
+  test "types returns registered type identifiers as strings" do
+    @registry.register(:http, name: "HTTP", icon: "🌐")
+    @registry.register(:smtp, name: "SMTP", icon: "✉️")
+
+    assert_equal %w[http smtp], @registry.types
+  end
+
+  test "find returns nil for an unregistered type" do
+    assert_nil @registry.find(:nonexistent)
+  end
+
+  test "each yields all registered probe types" do
+    @registry.register(:http, name: "HTTP", icon: "🌐")
+    @registry.register(:smtp, name: "SMTP", icon: "✉️")
+
+    names = @registry.map(&:name)
+    assert_equal %w[HTTP SMTP], names
+  end
+
+  test "built-in probe types are registered by the engine" do
+    assert_includes Upright.probe_types, "http"
+    assert_includes Upright.probe_types, "playwright"
+    assert_includes Upright.probe_types, "smtp"
+    assert_includes Upright.probe_types, "traceroute"
+  end
+
+  test "register_probe_type on Upright module adds to the global registry" do
+    Upright.register_probe_type :test_probe, name: "Test", icon: "🧪"
+
+    assert_includes Upright.probe_types, "test_probe"
+    assert_equal "🧪", Upright.probe_type_registry.find(:test_probe).icon
+  ensure
+    Upright.probe_type_registry.instance_variable_get(:@probe_types).reject! { |pt| pt.type == "test_probe" }
+  end
+end

--- a/test/lib/upright/probe_type_registry_test.rb
+++ b/test/lib/upright/probe_type_registry_test.rb
@@ -47,18 +47,20 @@ class Upright::ProbeTypeRegistryTest < ActiveSupport::TestCase
   end
 
   test "built-in probe types are registered by the engine" do
-    assert_includes Upright.probe_types, "http"
-    assert_includes Upright.probe_types, "playwright"
-    assert_includes Upright.probe_types, "smtp"
-    assert_includes Upright.probe_types, "traceroute"
+    probe_types = Upright.probe_types
+
+    assert_includes probe_types.types, "http"
+    assert_includes probe_types.types, "playwright"
+    assert_includes probe_types.types, "smtp"
+    assert_includes probe_types.types, "traceroute"
   end
 
-  test "register_probe_type on Upright module adds to the global registry" do
-    Upright.register_probe_type :test_probe, name: "Test", icon: "🧪"
+  test "registering via config.probe_types adds to the registry" do
+    Upright.config.probe_types.register :test_probe, name: "Test", icon: "🧪"
 
-    assert_includes Upright.probe_types, "test_probe"
-    assert_equal "🧪", Upright.probe_type_registry.find(:test_probe).icon
+    assert_includes Upright.probe_types.types, "test_probe"
+    assert_equal "🧪", Upright.probe_types.find(:test_probe).icon
   ensure
-    Upright.probe_type_registry.instance_variable_get(:@probe_types).reject! { |pt| pt.type == "test_probe" }
+    Upright.probe_types.instance_variable_get(:@probe_types).reject! { |pt| pt.type == "test_probe" }
   end
 end

--- a/test/lib/upright/probe_type_registry_test.rb
+++ b/test/lib/upright/probe_type_registry_test.rb
@@ -61,6 +61,6 @@ class Upright::ProbeTypeRegistryTest < ActiveSupport::TestCase
     assert_includes Upright.probe_types.types, "test_probe"
     assert_equal "🧪", Upright.probe_types.find(:test_probe).icon
   ensure
-    Upright.probe_types.instance_variable_get(:@probe_types).reject! { |pt| pt.type == "test_probe" }
+    Upright.probe_types.unregister(:test_probe)
   end
 end


### PR DESCRIPTION
## Summary

- Introduces a `ProbeTypeRegistry` so host apps can register custom probe types with a name and icon via `config.probe_types.register`
- Built-in types (HTTP, Playwright, SMTP, Traceroute) are pre-registered by the engine before host app initializers run
- All views (filter links, dashboard dropdowns) now render dynamically from the registry instead of hardcoded lists
- Removes the `Upright::Probeable::TYPES` constant and `PROBE_TYPE_ICONS` hash in favor of the registry
- Adds a working Ping probe example to the dummy app and documents the full custom probe type workflow in the README

```ruby
# config/initializers/upright.rb
Upright.configure do |config|
  config.probe_types.register :ping, name: "Ping", icon: "📶"
end
```

Closes #42

Thanks to @ttilberg for the idea.

## Test plan

- [x] All existing tests pass (155 runs, 330 assertions, 0 failures)
- [x] New registry unit tests cover register, replace, find, each, string/symbol identifiers, built-in types, and config access
- [x] New integration test asserts all registered types (including custom) render in filter links
- [x] Dummy app Ping probe runs and records results with artifact attachment