### PR TITLE
Purge stale probe results without destroy_all's job cascade

### DIFF
--- a/app/models/concerns/upright/probe_result/stale_cleanup.rb
+++ b/app/models/concerns/upright/probe_result/stale_cleanup.rb
@@ -8,7 +8,7 @@ module Upright::ProbeResult::StaleCleanup
     end
 
     def cleanup_stale_successes
-      ok.where(created_at: ...Upright.config.stale_success_threshold.ago).in_batches.destroy_all
+      ok.where(created_at: ...Upright.config.stale_success_threshold.ago).purge_in_batches
     end
 
     def cleanup_stale_failures
@@ -17,7 +17,31 @@ module Upright::ProbeResult::StaleCleanup
         fail.order(created_at: :desc).offset(Upright.config.failure_retention_limit).pick(:created_at)
       ].compact.max
 
-      fail.where(created_at: ..cutoff).in_batches.destroy_all
+      fail.where(created_at: ..cutoff).purge_in_batches
+    end
+
+    # Delete records and their artifacts without going through destroy_all's
+    # per-record callback cascade. has_many_attached's default dependent is
+    # :purge_later, which enqueues one ActiveStorage::PurgeJob per attachment
+    # — at ~13k attachments per hourly run on a busy site, that floods the
+    # queue DB enough to contend with probe writes. Here we issue batched
+    # DELETEs for the records and their attachment rows, then purge blobs
+    # inline so no jobs are enqueued.
+    def purge_in_batches
+      in_batches do |batch|
+        batch_ids = batch.pluck(:id)
+        attachments = ActiveStorage::Attachment.where(record_type: name, record_id: batch_ids)
+        blob_ids = attachments.pluck(:blob_id)
+
+        attachments.delete_all
+        batch.delete_all
+
+        ActiveStorage::Blob.where(id: blob_ids).find_each do |blob|
+          blob.purge
+        rescue => e
+          Rails.error.report(e)
+        end
+      end
     end
   end
 end

--- a/app/models/concerns/upright/probe_result/stale_cleanup.rb
+++ b/app/models/concerns/upright/probe_result/stale_cleanup.rb
@@ -31,12 +31,12 @@ module Upright::ProbeResult::StaleCleanup
       in_batches do |batch|
         batch_ids = batch.pluck(:id)
         attachments = ActiveStorage::Attachment.where(record_type: name, record_id: batch_ids)
-        blob_ids = attachments.pluck(:blob_id)
+        blob_ids = attachments.distinct.pluck(:blob_id)
 
         attachments.delete_all
         batch.delete_all
 
-        ActiveStorage::Blob.where(id: blob_ids).find_each do |blob|
+        ActiveStorage::Blob.unattached.where(id: blob_ids).find_each do |blob|
           blob.purge
         rescue => e
           Rails.error.report(e)

--- a/test/fixtures/active_storage/attachments.yml
+++ b/test/fixtures/active_storage/attachments.yml
@@ -22,3 +22,8 @@ playwright_video_artifact:
   name: artifacts
   record: playwright_probe_result (Upright::ProbeResult)
   blob: playwright_video
+
+stale_artifact:
+  name: artifacts
+  record: stale_success (Upright::ProbeResult)
+  blob: stale_log

--- a/test/fixtures/active_storage/blobs.yml
+++ b/test/fixtures/active_storage/blobs.yml
@@ -45,3 +45,11 @@ playwright_video:
   service_name: local
   byte_size: 100
   checksum: <%= Digest::MD5.base64digest("fake video content") %>
+
+stale_log:
+  key: stale_log_key
+  filename: curl.log
+  content_type: text/plain
+  service_name: local
+  byte_size: 30
+  checksum: <%= Digest::MD5.base64digest("Sample log content for testing") %>

--- a/test/models/upright/probe_result_test.rb
+++ b/test/models/upright/probe_result_test.rb
@@ -1,6 +1,7 @@
 require "test_helper"
 
 class Upright::ProbeResultTest < ActiveSupport::TestCase
+  include ActiveJob::TestHelper
   test ".to_chart returns expected structure" do
     result = upright_probe_results(:http_probe_result)
     chart_data = result.to_chart
@@ -39,6 +40,23 @@ class Upright::ProbeResultTest < ActiveSupport::TestCase
     assert Upright::ProbeResult.exists?(fresh_success_id)
     assert_not Upright::ProbeResult.exists?(stale_failure_id)
     assert Upright::ProbeResult.exists?(recent_failure_id)
+  end
+
+  test ".cleanup_stale purges attachments and blobs for stale records without enqueuing jobs" do
+    stale = upright_probe_results(:stale_success)
+    stale_attachment_id = stale.artifacts.first.id
+    stale_blob_id = stale.artifacts.first.blob.id
+
+    fresh = upright_probe_results(:http_probe_result)
+    fresh_blob_id = fresh.artifacts.first.blob.id
+
+    assert_no_enqueued_jobs do
+      Upright::ProbeResult.cleanup_stale
+    end
+
+    assert_not ActiveStorage::Attachment.exists?(stale_attachment_id)
+    assert_not ActiveStorage::Blob.exists?(stale_blob_id)
+    assert ActiveStorage::Blob.exists?(fresh_blob_id)
   end
 
   test ".cleanup_stale caps failures at retention limit" do


### PR DESCRIPTION
## Summary

`Upright::ProbeResult.cleanup_stale` was calling `in_batches.destroy_all` on stale records. Because `has_many_attached :artifacts` defaults to `dependent: :purge_later`, every destroy enqueued one `ActiveStorage::PurgeJob` per attachment — ~13k jobs per hourly run on a busy site. That flooded the queue DB, contended with probe writes through SQLite's single writer, and (on latency-sensitive sites like blr) tipped HTTP probes past their 10s Typhoeus timeout.

Replace the cascade with a relation-level `.purge_in_batches`:

```ruby
def cleanup_stale_successes
  ok.where(created_at: ...Upright.config.stale_success_threshold.ago).purge_in_batches
end
```

Which issues batched `DELETE`s for the records and their attachment rows, then purges blobs inline. **No jobs are enqueued** and the write lock is released between batches.

Behavior is unchanged externally — stale records, their attachments, and their blob files are still gone after a cleanup run.

## Why

Bangalore has been flapping HTTP probes in 2–3 minute windows at :30 every hour. Root-cause diagnosis is in https://3.basecamp.com/2914079/buckets/43768667/card_tables/cards/9812504277. SQLite pragma tuning (already deployed) helped at the margin but didn't address the underlying work amplification — this PR does.

## Test plan

- [x] Existing `.cleanup_stale` tests still pass
- [x] New test: stale records' attachments and blobs are purged
- [x] New test: `assert_no_enqueued_jobs` — cleanup doesn't flood SolidQueue
- [x] New test: non-stale records' blobs are preserved
- [x] Full engine test suite green (155 runs, 0 failures)
- [ ] Bump gem ref in basecamp/37upright, deploy to blr, watch the next :30 cleanup window