### PR TITLE
Use HTTPS + secure cookies in all deployed environments

### DIFF
--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -134,10 +134,10 @@ class Upright::Configuration
   end
 
   def default_url_options
-    if Rails.env.production?
-      { protocol: "https", host: "#{global_subdomain}.#{hostname}", domain: hostname }
-    else
+    if Rails.env.local?
       { protocol: "http", host: "#{global_subdomain}.#{hostname}", port: ENV.fetch("PORT", 3000).to_i, domain: hostname }
+    else
+      { protocol: "https", host: "#{global_subdomain}.#{hostname}", domain: hostname }
     end
   end
 

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -10,7 +10,7 @@ class Upright::Engine < ::Rails::Engine
       key: "_upright_session",
       domain: :all,
       same_site: :lax,
-      secure: Rails.env.production?,
+      secure: !Rails.env.local?,
       expire_after: 24.hours
   end
 


### PR DESCRIPTION
Key `default_url_options` and the session cookie `secure` flag on `Rails.env.local?` instead of `Rails.env.production?`, so deployed non-prod envs (staging) get https + secure cookies instead of unreachable `http://host:3000` URLs. Dev/test unchanged.