### PR TITLE
Show an environment badge in the header outside production

### DIFF
--- a/app/assets/stylesheets/upright/_global.css
+++ b/app/assets/stylesheets/upright/_global.css
@@ -35,6 +35,7 @@
 
   --lch-green-dark: 55% 0.162 147;
   --lch-red-dark: 59% 0.19 38;
+  --lch-orange-dark: 70% 0.17 65;
 
   /* Colors: Semantic */
   --color-black: oklch(var(--lch-black));
@@ -52,6 +53,7 @@
   --color-link: oklch(var(--lch-blue-dark));
   --color-positive: oklch(var(--lch-green-dark));
   --color-negative: oklch(var(--lch-red-dark));
+  --color-warning: oklch(var(--lch-orange-dark));
   --color-selected: oklch(var(--lch-blue-lighter));
 
   /* Borders & Shadows */

--- a/app/assets/stylesheets/upright/header.css
+++ b/app/assets/stylesheets/upright/header.css
@@ -38,6 +38,15 @@
     text-transform: uppercase;
   }
 
+  .header__env {
+    color: var(--color-warning);
+    font-size: var(--text-x-small);
+    font-weight: 500;
+    letter-spacing: 0.06em;
+    margin-right: calc(var(--inline-space) * 2);
+    text-transform: uppercase;
+  }
+
   .header__nav {
     align-items: center;
     display: flex;

--- a/app/views/layouts/upright/_header.html.erb
+++ b/app/views/layouts/upright/_header.html.erb
@@ -4,6 +4,9 @@
     <% if Upright::Current.site.present? %>
       <span class="header__site"><%= site_name(Upright::Current.site) %></span>
     <% end %>
+    <% unless Rails.env.production? %>
+      <span class="header__env"><%= Rails.env %></span>
+    <% end %>
   </div>
 
   <nav class="header__nav">


### PR DESCRIPTION
Adds an orange env label (e.g. `staging`) after the site name in the header, so it's obvious when you're not on production. Hidden in production. Adds a `--color-warning` (orange) palette token.