### PR TITLE
Give probe_result duration sub-second precision

### DIFF
--- a/db/migrate/20260629000001_fix_probe_result_duration_precision.rb
+++ b/db/migrate/20260629000001_fix_probe_result_duration_precision.rb
@@ -1,0 +1,14 @@
+class FixProbeResultDurationPrecision < ActiveRecord::Migration[8.0]
+  # `t.decimal :duration` with no precision becomes DECIMAL(10,0) on MySQL,
+  # which rounds every duration to a whole second on write. Probe durations
+  # are sub-second floats from a monotonic clock, so they were all stored as
+  # 0. SQLite preserved the fractional value, which is why this only surfaced
+  # after the MySQL migration. Give the column microsecond precision.
+  def up
+    change_column :upright_probe_results, :duration, :decimal, precision: 10, scale: 6
+  end
+
+  def down
+    change_column :upright_probe_results, :duration, :decimal
+  end
+end

--- a/test/dummy/db/schema.rb
+++ b/test/dummy/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2025_01_14_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_29_000001) do
   create_table "active_storage_attachments", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -41,7 +41,7 @@ ActiveRecord::Schema[8.1].define(version: 2025_01_14_000001) do
 
   create_table "upright_probe_results", force: :cascade do |t|
     t.datetime "created_at", null: false
-    t.decimal "duration"
+    t.decimal "duration", precision: 10, scale: 6
     t.string "probe_name"
     t.string "probe_service"
     t.string "probe_target"


### PR DESCRIPTION
## Problem

After the SQLite → MySQL migration, the **duration** of most probe results renders as `0.00s` in production.

The `duration` column is declared as `t.decimal :duration` with no precision (`db/migrate/20250114000001_create_upright_probe_results.rb`). Duration is computed from a monotonic clock and is almost always sub-second:

```ruby
# app/models/concerns/upright/probeable.rb
def measure
  start_time = monotonic_now
  result = yield
  [ result, monotonic_now - start_time ]   # float seconds, e.g. 0.043
end
```

On **SQLite**, NUMERIC affinity stored the full float (`0.043`). On **MySQL**, `DECIMAL` with no scale defaults to `DECIMAL(10,0)` — zero digits after the point — so every value is rounded to a whole second on write:

- `0.043s` → `0`
- `0.6s` → `1`

Most checks finish well under a second, so they store `0` and display as `0.00s`.

## Fix

New migration altering the column to `DECIMAL(10,6)` (microsecond precision; max ~9999s). Dummy schema dump updated to match.

## Caveats

- Rows already written as `0` were rounded on insert and **cannot be recovered**; only probe results recorded after the migration runs will be correct.
- This is the engine migration that runs in host apps (e.g. `37upright`) via the appended migration path, so deploying the bumped gem fixes production. Host bump: basecamp/37upright (companion PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)