### PR TITLE
Make the services definition path env-overridable

### DIFF
--- a/app/models/upright/service.rb
+++ b/app/models/upright/service.rb
@@ -2,7 +2,7 @@ class Upright::Service < FrozenRecord::Base
   include Upright::Services::LiveStatus
 
   def self.file_path
-    Rails.root.join("config", "services.yml").to_s
+    Upright.configuration.services_path.to_s
   end
 
   scope :public_facing, -> { where(public: true) }

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -21,6 +21,9 @@ class Upright::Configuration
   attr_writer :probes_path
   attr_writer :authenticators_path
 
+  # Public status page services definition (env-overridable, like probes_path)
+  attr_writer :services_path
+
   # Playwright
   attr_accessor :playwright_cli_path
 
@@ -57,6 +60,7 @@ class Upright::Configuration
     @frozen_record_path = nil
     @probes_path = nil
     @authenticators_path = nil
+    @services_path = nil
 
     @probe_types = Upright::ProbeTypeRegistry.new
 
@@ -118,6 +122,10 @@ class Upright::Configuration
 
   def probes_path
     @probes_path || Rails.root.join("probes")
+  end
+
+  def services_path
+    @services_path || Rails.root.join("config", "services.yml")
   end
 
   def authenticators_path


### PR DESCRIPTION
Adds `Upright.config.services_path` (defaults to `config/services.yml`) and has `Upright::Service` read from it, mirroring `probes_path`. This lets a host point a given environment at a different services file so the public status page reflects that environment's actual probe set.

Backward-compatible: the default is unchanged, so existing installs (and the dummy app) behave exactly as before.

Paired with 37upright's `staging-services-config` branch, which sets `services_path` to a staging-only services file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)