### PR TITLE
Show uptime to three decimals; never round an outage up to 100%

### DIFF
--- a/app/helpers/upright/public/services_helper.rb
+++ b/app/helpers/upright/public/services_helper.rb
@@ -29,9 +29,12 @@ module Upright::Public::ServicesHelper
     [ issue[:service].code, issue[:started_at]&.to_i ].compact.join("-")
   end
 
-  def average_uptime_percentage(fractions)
+  def uptime_percentage_label(fractions)
     if fractions.present?
-      (fractions.sum.to_f / fractions.size) * 100
+      percentage = fractions.sum.fdiv(fractions.size) * 100
+      # Round down so a real outage never reads as 100%; strip zeros so a
+      # flawless window is a bare "100%", not "100.000%".
+      number_to_percentage(percentage, precision: 3, round_mode: :down, strip_insignificant_zeros: true)
     end
   end
 end

--- a/app/views/upright/public/services/_service.html.erb
+++ b/app/views/upright/public/services/_service.html.erb
@@ -1,5 +1,4 @@
 <% today_status = history.last.status %>
-<% avg = average_uptime_percentage(history.map(&:uptime_fraction).compact) %>
 
 <section class="service">
   <div class="service__row">
@@ -20,8 +19,8 @@
 
     <div class="uptime__meta">
       <span><%= history.size %> days ago</span>
-      <% if avg %>
-        <span class="uptime__meta-percent"><%= '%.2f' % avg %>% uptime</span>
+      <% if uptime = uptime_percentage_label(history.map(&:uptime_fraction).compact) %>
+        <span class="uptime__meta-percent"><%= uptime %> uptime</span>
       <% else %>
         <span class="uptime__meta-percent">No data yet</span>
       <% end %>

--- a/test/helpers/upright/public/services_helper_test.rb
+++ b/test/helpers/upright/public/services_helper_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class Upright::Public::ServicesHelperTest < ActionView::TestCase
+  test "no data yields nil" do
+    assert_nil uptime_percentage_label([])
+  end
+
+  test "a flawless window reads as a bare 100%" do
+    assert_equal "100%", uptime_percentage_label([ 1.0, 1.0, 1.0 ])
+  end
+
+  test "a tiny outage never rounds up to 100%" do
+    # One 1-minute outage over 90 days ≈ 99.99923% — must not display as 100%.
+    fractions = [ 1.0 - 1.0 / 1440 ] + Array.new(89, 1.0)
+    assert_equal "99.999%", uptime_percentage_label(fractions)
+  end
+
+  test "trailing zeros are trimmed" do
+    assert_equal "99.5%", uptime_percentage_label([ 0.995 ])
+  end
+
+  test "floors rather than rounds to three decimals" do
+    assert_equal "99.999%", uptime_percentage_label([ 0.9999995 ])
+  end
+end


### PR DESCRIPTION
A service's overall uptime figure was the mean of its daily fractions shown as `%.2f`. A real outage too small to register at two decimals — e.g. a 1-minute blip over 90 days ≈ 99.99923% — displayed as **100.00%**, contradicting the degraded day visible in the same service's bar chart.

Now shows **three decimals and floors** (not rounds), so any real downtime reads as `99.999%` while a genuinely flawless window still shows a bare `100%` (not `100.000%`). Trailing zeros are trimmed.

Surfaced by the Statuspage history backfill in 37upright: Basecamp 2 has a day with a 1-minute outage (99.93% that day), yet the headline read 100.00%.

Added `Upright::Public::ServicesHelperTest` covering the bare-100%, tiny-outage, trailing-zero, and floor-not-round cases.

🤖 Generated with [Claude Code](https://claude.com/claude-code)