### PR TITLE
Record who created and updated incidents

### DIFF
--- a/app/assets/stylesheets/upright/incidents.css
+++ b/app/assets/stylesheets/upright/incidents.css
@@ -428,6 +428,12 @@
     margin-left: 0.5rem;
   }
 
+  .timeline__author {
+    color: var(--color-ink-medium);
+    font-size: var(--text-x-small);
+    margin-left: 0.5rem;
+  }
+
   .timeline__body {
     color: var(--color-ink-dark);
     font-size: var(--text-small);

--- a/app/models/upright/incident.rb
+++ b/app/models/upright/incident.rb
@@ -25,6 +25,8 @@ class Upright::Incident < Upright::PersistentRecord
   validates :impact, inclusion: { in: ->(incident) { incident.class::IMPACTS } }
 
   before_validation :set_default_status, on: :create
+  before_create { self.created_by ||= Upright::Current.user&.name }
+  before_update { self.updated_by = Upright::Current.user.name if Upright::Current.user }
   after_create :record_initial_update
 
   def maintenance? = false

--- a/app/models/upright/incident_update.rb
+++ b/app/models/upright/incident_update.rb
@@ -2,4 +2,6 @@ class Upright::IncidentUpdate < Upright::PersistentRecord
   belongs_to :incident, class_name: "Upright::Incident", inverse_of: :updates
 
   validates :status, presence: true
+
+  before_create { self.created_by ||= Upright::Current.user&.name }
 end

--- a/app/models/upright/incident_update.rb
+++ b/app/models/upright/incident_update.rb
@@ -3,5 +3,5 @@ class Upright::IncidentUpdate < Upright::PersistentRecord
 
   validates :status, presence: true
 
-  before_create { self.created_by ||= Upright::Current.user&.name }
+  before_create { self.created_by ||= Upright::Current.user&.name || "System" }
 end

--- a/app/views/upright/incidents/_row.html.erb
+++ b/app/views/upright/incidents/_row.html.erb
@@ -9,6 +9,7 @@
     <p class="incident-row__meta">
       <% if incident.services.any? %><%= incident.services.map(&:name).to_sentence %> · <% end %>
       <time datetime="<%= incident.starts_at.iso8601 %>"><%= when_label %></time>
+      <% if incident.created_by.present? %> · Declared by <%= incident.created_by %><% end %>
     </p>
   </div>
 <% end %>

--- a/app/views/upright/incidents/edit.html.erb
+++ b/app/views/upright/incidents/edit.html.erb
@@ -41,7 +41,7 @@
         <li class="timeline__item">
           <span class="timeline__status"><%= update.status.humanize %></span>
           <time class="timeline__time" datetime="<%= update.created_at.iso8601 %>"><%= update.created_at.strftime("%b %-d, %H:%M %Z") %></time>
-          <span class="timeline__author">by <%= update.created_by.presence || "System" %></span>
+          <span class="timeline__author">by <%= update.created_by %></span>
           <% if update.body.present? %><p class="timeline__body"><%= update.body %></p><% end %>
         </li>
       <% end %>

--- a/app/views/upright/incidents/edit.html.erb
+++ b/app/views/upright/incidents/edit.html.erb
@@ -41,6 +41,7 @@
         <li class="timeline__item">
           <span class="timeline__status"><%= update.status.humanize %></span>
           <time class="timeline__time" datetime="<%= update.created_at.iso8601 %>"><%= update.created_at.strftime("%b %-d, %H:%M %Z") %></time>
+          <span class="timeline__author">by <%= update.created_by.presence || "System" %></span>
           <% if update.body.present? %><p class="timeline__body"><%= update.body %></p><% end %>
         </li>
       <% end %>

--- a/db/persistent_migrate/20260709000001_add_created_by_to_incidents.rb
+++ b/db/persistent_migrate/20260709000001_add_created_by_to_incidents.rb
@@ -1,0 +1,7 @@
+class AddCreatedByToIncidents < ActiveRecord::Migration[8.0]
+  def change
+    add_column :upright_incidents, :created_by, :string
+    add_column :upright_incidents, :updated_by, :string
+    add_column :upright_incident_updates, :created_by, :string
+  end
+end

--- a/test/dummy/config/database.yml
+++ b/test/dummy/config/database.yml
@@ -20,7 +20,9 @@ development:
   persistent:
     <<: *default
     database: storage/development_persistent.sqlite3
-    migrations_paths: ../../db/persistent_migrate
+    migrations_paths:
+      - db/persistent_migrate
+      - ../../db/persistent_migrate
   queue:
     <<: *default
     database: storage/development_queue.sqlite3
@@ -36,7 +38,9 @@ test:
   persistent:
     <<: *default
     database: storage/test_persistent.sqlite3
-    migrations_paths: ../../db/persistent_migrate
+    migrations_paths:
+      - db/persistent_migrate
+      - ../../db/persistent_migrate
   queue:
     <<: *default
     database: storage/test_queue.sqlite3

--- a/test/dummy/db/persistent_schema.rb
+++ b/test/dummy/db/persistent_schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_07_000001) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_09_000001) do
   create_table "upright_incident_affected_services", force: :cascade do |t|
     t.integer "incident_id", null: false
     t.string "service_code", null: false
@@ -22,6 +22,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_000001) do
   create_table "upright_incident_updates", force: :cascade do |t|
     t.text "body"
     t.datetime "created_at", null: false
+    t.string "created_by"
     t.integer "incident_id", null: false
     t.string "status", null: false
     t.index ["incident_id"], name: "index_upright_incident_updates_on_incident_id"
@@ -29,6 +30,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_000001) do
 
   create_table "upright_incidents", force: :cascade do |t|
     t.datetime "created_at", null: false
+    t.string "created_by"
     t.datetime "ends_at"
     t.string "impact", null: false
     t.datetime "resolved_at"
@@ -37,6 +39,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_07_000001) do
     t.string "title", null: false
     t.string "type"
     t.datetime "updated_at", null: false
+    t.string "updated_by"
     t.index ["resolved_at", "starts_at"], name: "index_upright_incidents_on_resolved_at_and_starts_at"
     t.index ["type", "starts_at"], name: "index_upright_incidents_on_type_and_starts_at"
   end

--- a/test/fixtures/upright_incidents.yml
+++ b/test/fixtures/upright_incidents.yml
@@ -40,7 +40,7 @@ reactive_resolved:
   status: resolved
   starts_at: 2026-06-15 10:00:00
   resolved_at: 2026-06-15 11:00:00
-  created_by: "Ada Lovelace"
+  created_by: "Lewis Buckley"
 
 reactive_other:
   type: Upright::Incident

--- a/test/fixtures/upright_incidents.yml
+++ b/test/fixtures/upright_incidents.yml
@@ -40,6 +40,7 @@ reactive_resolved:
   status: resolved
   starts_at: 2026-06-15 10:00:00
   resolved_at: 2026-06-15 11:00:00
+  created_by: "Ada Lovelace"
 
 reactive_other:
   type: Upright::Incident

--- a/test/integration/public/incidents_controller_test.rb
+++ b/test/integration/public/incidents_controller_test.rb
@@ -10,6 +10,6 @@ class Upright::Public::IncidentsControllerTest < ActionDispatch::IntegrationTest
     get upright.public_incident_path(incident)
 
     assert_response :success
-    assert_no_match "Lewis Buckley", response.body
+    assert_no_match(/Lewis Buckley/, response.body)
   end
 end

--- a/test/integration/public/incidents_controller_test.rb
+++ b/test/integration/public/incidents_controller_test.rb
@@ -5,11 +5,11 @@ class Upright::Public::IncidentsControllerTest < ActionDispatch::IntegrationTest
 
   test "incident detail never shows the author" do
     incident = upright_incidents(:reactive_resolved)
-    assert_equal "Ada Lovelace", incident.created_by
+    assert_equal "Lewis Buckley", incident.created_by
 
     get upright.public_incident_path(incident)
 
     assert_response :success
-    assert_no_match "Ada Lovelace", response.body
+    assert_no_match "Lewis Buckley", response.body
   end
 end

--- a/test/integration/public/incidents_controller_test.rb
+++ b/test/integration/public/incidents_controller_test.rb
@@ -1,0 +1,16 @@
+require "test_helper"
+
+class Upright::Public::IncidentsControllerTest < ActionDispatch::IntegrationTest
+  setup { on_subdomain Upright.configuration.public_status_subdomain }
+
+  test "incident detail never shows the author" do
+    incident = Upright::Incident.create!(
+      title: "Public incident", impact: "minor", starts_at: Time.current, created_by: "Ada Lovelace"
+    )
+
+    get upright.public_incident_path(incident)
+
+    assert_response :success
+    assert_no_match "Ada Lovelace", response.body
+  end
+end

--- a/test/integration/public/incidents_controller_test.rb
+++ b/test/integration/public/incidents_controller_test.rb
@@ -4,9 +4,8 @@ class Upright::Public::IncidentsControllerTest < ActionDispatch::IntegrationTest
   setup { on_subdomain Upright.configuration.public_status_subdomain }
 
   test "incident detail never shows the author" do
-    incident = Upright::Incident.create!(
-      title: "Public incident", impact: "minor", starts_at: Time.current, created_by: "Ada Lovelace"
-    )
+    incident = upright_incidents(:reactive_resolved)
+    assert_equal "Ada Lovelace", incident.created_by
 
     get upright.public_incident_path(incident)
 

--- a/test/lib/helpers/current_user_helper.rb
+++ b/test/lib/helpers/current_user_helper.rb
@@ -1,0 +1,5 @@
+module CurrentUserHelper
+  def acting_as(name, email: "user@example.com")
+    Upright::Current.user = Upright::User.new(name: name, email: email)
+  end
+end

--- a/test/models/upright/incident_test.rb
+++ b/test/models/upright/incident_test.rb
@@ -97,12 +97,12 @@ class Upright::IncidentTest < ActiveSupport::TestCase
   end
 
   test "declaring an incident stamps created_by on the incident and its initial update" do
-    acting_as "Grace Hopper"
+    acting_as "Eron Nicholson"
 
     incident = Upright::Incident.create!(title: "New outage", impact: "minor", starts_at: Time.current)
 
-    assert_equal "Grace Hopper", incident.created_by
-    assert_equal "Grace Hopper", incident.updates.first.created_by
+    assert_equal "Eron Nicholson", incident.created_by
+    assert_equal "Eron Nicholson", incident.updates.first.created_by
     assert_nil incident.updated_by
   end
 
@@ -110,21 +110,21 @@ class Upright::IncidentTest < ActiveSupport::TestCase
     incident = upright_incidents(:reactive_resolved)
     assert_nil incident.updated_by
 
-    acting_as "Grace Hopper"
+    acting_as "Eron Nicholson"
     incident.update!(title: "Renamed outage")
 
-    assert_equal "Grace Hopper", incident.updated_by
+    assert_equal "Eron Nicholson", incident.updated_by
   end
 
   test "posting an update stamps created_by from the current user" do
     incident = activate(upright_incidents(:reactive_resolved))
-    acting_as "Katherine Johnson"
+    acting_as "Silvia Uberti"
 
     update = incident.record_update(status: "monitoring", body: "Watching recovery.")
 
     assert update.persisted?
-    assert_equal "Katherine Johnson", update.created_by
-    assert_equal "Katherine Johnson", incident.reload.updated_by
+    assert_equal "Silvia Uberti", update.created_by
+    assert_equal "Silvia Uberti", incident.reload.updated_by
   end
 
   test "updates posted without a current user are authored by System" do

--- a/test/models/upright/incident_test.rb
+++ b/test/models/upright/incident_test.rb
@@ -97,7 +97,7 @@ class Upright::IncidentTest < ActiveSupport::TestCase
   end
 
   test "declaring an incident stamps created_by on the incident and its initial update" do
-    Upright::Current.user = Upright::User.new(name: "Grace Hopper", email: "grace@example.com")
+    acting_as "Grace Hopper"
 
     incident = Upright::Incident.create!(title: "New outage", impact: "minor", starts_at: Time.current)
 
@@ -110,7 +110,7 @@ class Upright::IncidentTest < ActiveSupport::TestCase
     incident = upright_incidents(:reactive_resolved)
     assert_nil incident.updated_by
 
-    Upright::Current.user = Upright::User.new(name: "Grace Hopper", email: "grace@example.com")
+    acting_as "Grace Hopper"
     incident.update!(title: "Renamed outage")
 
     assert_equal "Grace Hopper", incident.updated_by
@@ -118,7 +118,7 @@ class Upright::IncidentTest < ActiveSupport::TestCase
 
   test "posting an update stamps created_by from the current user" do
     incident = activate(upright_incidents(:reactive_resolved))
-    Upright::Current.user = Upright::User.new(name: "Katherine Johnson", email: "katherine@example.com")
+    acting_as "Katherine Johnson"
 
     update = incident.record_update(status: "monitoring", body: "Watching recovery.")
 

--- a/test/models/upright/incident_test.rb
+++ b/test/models/upright/incident_test.rb
@@ -96,6 +96,48 @@ class Upright::IncidentTest < ActiveSupport::TestCase
     assert_not_includes Upright::Incident.for_service("internal_tools"), incident
   end
 
+  test "declaring an incident stamps created_by on the incident and its initial update" do
+    Upright::Current.user = Upright::User.new(name: "Ada Lovelace", email: "ada@example.com")
+
+    incident = Upright::Incident.create!(title: "x", impact: "minor", starts_at: Time.current)
+
+    assert_equal "Ada Lovelace", incident.created_by
+    assert_equal "Ada Lovelace", incident.updates.first.created_by
+    assert_nil incident.updated_by
+  end
+
+  test "editing an incident stamps updated_by from the current user" do
+    incident = Upright::Incident.create!(title: "x", impact: "minor", starts_at: Time.current)
+    assert_nil incident.updated_by
+
+    Upright::Current.user = Upright::User.new(name: "Grace Hopper", email: "grace@example.com")
+    incident.update!(title: "y")
+
+    assert_equal "Grace Hopper", incident.updated_by
+  end
+
+  test "posting an update stamps created_by from the current user" do
+    incident = activate(upright_incidents(:reactive_resolved))
+    Upright::Current.user = Upright::User.new(name: "Katherine Johnson", email: "katherine@example.com")
+
+    update = incident.record_update(status: "monitoring", body: "Watching recovery.")
+
+    assert update.persisted?
+    assert_equal "Katherine Johnson", update.created_by
+    assert_equal "Katherine Johnson", incident.reload.updated_by
+  end
+
+  test "system-posted maintenance updates carry no author" do
+    maintenance = Upright::Maintenance.create!(title: "Upgrade", starts_at: 1.hour.ago, ends_at: 1.hour.from_now)
+
+    maintenance.auto_advance_status
+
+    update = maintenance.updates.find_by(status: "in_progress")
+    assert_not_nil update
+    assert_nil update.created_by
+    assert_nil maintenance.reload.updated_by
+  end
+
   private
     def activate(incident, **overrides)
       incident.update!({ status: "investigating", starts_at: 1.hour.ago, resolved_at: nil }.merge(overrides))

--- a/test/models/upright/incident_test.rb
+++ b/test/models/upright/incident_test.rb
@@ -97,21 +97,21 @@ class Upright::IncidentTest < ActiveSupport::TestCase
   end
 
   test "declaring an incident stamps created_by on the incident and its initial update" do
-    Upright::Current.user = Upright::User.new(name: "Ada Lovelace", email: "ada@example.com")
+    Upright::Current.user = Upright::User.new(name: "Grace Hopper", email: "grace@example.com")
 
-    incident = Upright::Incident.create!(title: "x", impact: "minor", starts_at: Time.current)
+    incident = Upright::Incident.create!(title: "New outage", impact: "minor", starts_at: Time.current)
 
-    assert_equal "Ada Lovelace", incident.created_by
-    assert_equal "Ada Lovelace", incident.updates.first.created_by
+    assert_equal "Grace Hopper", incident.created_by
+    assert_equal "Grace Hopper", incident.updates.first.created_by
     assert_nil incident.updated_by
   end
 
   test "editing an incident stamps updated_by from the current user" do
-    incident = Upright::Incident.create!(title: "x", impact: "minor", starts_at: Time.current)
+    incident = upright_incidents(:reactive_resolved)
     assert_nil incident.updated_by
 
     Upright::Current.user = Upright::User.new(name: "Grace Hopper", email: "grace@example.com")
-    incident.update!(title: "y")
+    incident.update!(title: "Renamed outage")
 
     assert_equal "Grace Hopper", incident.updated_by
   end
@@ -127,14 +127,13 @@ class Upright::IncidentTest < ActiveSupport::TestCase
     assert_equal "Katherine Johnson", incident.reload.updated_by
   end
 
-  test "system-posted maintenance updates carry no author" do
-    maintenance = Upright::Maintenance.create!(title: "Upgrade", starts_at: 1.hour.ago, ends_at: 1.hour.from_now)
+  test "updates posted without a current user are authored by System" do
+    maintenance = upright_incidents(:started_scheduled)
 
     maintenance.auto_advance_status
 
     update = maintenance.updates.find_by(status: "in_progress")
-    assert_not_nil update
-    assert_nil update.created_by
+    assert_equal "System", update.created_by
     assert_nil maintenance.reload.updated_by
   end
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -26,6 +26,7 @@ module ActiveSupport
     # multiple Playwright containers for browser-based probes.
     parallelize(workers: 1)
 
+    include CurrentUserHelper
     include IpApiHelper
     include MtrHelper
     include RailsEnvHelper


### PR DESCRIPTION
Stamps the acting user's name onto incidents and their timeline updates (`created_by` / `updated_by`) and surfaces it on the admin `/incidents` views. The public status page never shows an author. Automated maintenance updates have no author.

Also fixes the dummy app's persistent `migrations_paths` so engine persistent migrations resolve from the engine root (mirrors the primary DB's dual-path config); previously `app:db:migrate` silently applied zero persistent migrations.