### PR TITLE
Support host-app design overrides on the public status page

### DIFF
--- a/app/assets/stylesheets/upright/public_status.css
+++ b/app/assets/stylesheets/upright/public_status.css
@@ -18,6 +18,35 @@
     padding: calc(var(--block-space) * 3) var(--main-padding);
   }
 
+  .status-header,
+  .status-footer {
+    margin: 0 auto;
+    max-width: 56rem;
+    padding: 0 var(--main-padding);
+  }
+
+  .status-header {
+    align-items: center;
+    display: flex;
+    gap: 0.75rem;
+    padding-top: calc(var(--block-space) * 2);
+  }
+
+  .status-header__label {
+    font-size: var(--text-large);
+    font-weight: 600;
+    letter-spacing: -0.01em;
+  }
+
+  .status-footer {
+    border-top: var(--border);
+    color: var(--color-ink-medium);
+    font-size: var(--text-small);
+    margin-top: calc(var(--block-space) * 2);
+    padding-bottom: calc(var(--block-space) * 3);
+    padding-top: calc(var(--block-space) * 1.5);
+  }
+
   .status-page__title {
     font-size: var(--text-x-large);
     font-weight: 600;

--- a/app/helpers/upright/application_helper.rb
+++ b/app/helpers/upright/application_helper.rb
@@ -12,9 +12,9 @@ module Upright::ApplicationHelper
   end
 
   def upright_stylesheet_link_tag(**options)
-    Upright::Engine.root.join("app/assets/stylesheets/upright").glob("*.css")
+    engine_stylesheets = Upright::Engine.root.join("app/assets/stylesheets/upright").glob("*.css")
       .map { |f| "upright/#{f.basename('.css')}" }.sort
-      .then { |stylesheets| stylesheet_link_tag(*stylesheets, **options) }
+    stylesheet_link_tag(*engine_stylesheets, *Upright.configuration.public_stylesheets, **options)
   end
 
   private

--- a/app/helpers/upright/public/services_helper.rb
+++ b/app/helpers/upright/public/services_helper.rb
@@ -57,9 +57,14 @@ module Upright::Public::ServicesHelper
   def uptime_percentage_label(fractions)
     if fractions.present?
       percentage = fractions.sum.fdiv(fractions.size) * 100
-      # Round down so a real outage never reads as 100%; strip zeros so a
-      # flawless window is a bare "100%", not "100.000%".
-      number_to_percentage(percentage, precision: 3, round_mode: :down, strip_insignificant_zeros: true)
+      # A flawless window is a bare "100%". Otherwise round down (so a real
+      # outage never reads as 100%) and always show three decimals for a
+      # consistent, precise read: "99.990%", "99.800%".
+      if percentage >= 100
+        number_to_percentage(100, precision: 0)
+      else
+        number_to_percentage(percentage, precision: 3, round_mode: :down)
+      end
     end
   end
 end

--- a/app/views/layouts/upright/public.html.erb
+++ b/app/views/layouts/upright/public.html.erb
@@ -8,8 +8,10 @@
     <%= upright_stylesheet_link_tag "data-turbo-track": "reload" %>
   </head>
   <body class="public">
+    <%= render "upright/public/branding" %>
     <main class="main">
       <%= yield %>
     </main>
+    <%= render "upright/public/footer" %>
   </body>
 </html>

--- a/app/views/upright/public/_branding.html.erb
+++ b/app/views/upright/public/_branding.html.erb
@@ -1,0 +1,3 @@
+<header class="status-header">
+  <span class="status-header__label"><%= Upright.configuration.service_name %></span>
+</header>

--- a/app/views/upright/public/_footer.html.erb
+++ b/app/views/upright/public/_footer.html.erb
@@ -1,0 +1,3 @@
+<footer class="status-footer">
+  <span class="status-footer__note">Powered by Upright</span>
+</footer>

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -48,6 +48,11 @@ class Upright::Configuration
   attr_accessor :public_status_enabled
   attr_reader :public_status_custom_domains
 
+  # Extra stylesheets host apps layer on top of the engine's for the public
+  # status page (theming, branding). Logical asset names, loaded last so their
+  # :root overrides win the cascade.
+  attr_writer :public_stylesheets
+
   def initialize
     @service_name = "upright"
     @user_agent = "Upright/1.0"
@@ -77,10 +82,15 @@ class Upright::Configuration
 
     @public_status_enabled = false
     @public_status_custom_domains = []
+    @public_stylesheets = nil
   end
 
   def public_status_subdomain
     PUBLIC_STATUS_SUBDOMAIN
+  end
+
+  def public_stylesheets
+    Array(@public_stylesheets)
   end
 
   def public_status_custom_domains=(domains)

--- a/test/dummy/app/assets/stylesheets/upright/theme.css
+++ b/test/dummy/app/assets/stylesheets/upright/theme.css
@@ -1,0 +1,2 @@
+/* Fixture demonstrating a host app layering a theme onto the public status
+   page via Upright.configuration.public_stylesheets. Inert unless configured. */

--- a/test/helpers/upright/application_helper_test.rb
+++ b/test/helpers/upright/application_helper_test.rb
@@ -1,0 +1,31 @@
+require "test_helper"
+
+class Upright::ApplicationHelperTest < ActionView::TestCase
+  test "public_stylesheets default to an empty array" do
+    assert_equal [], Upright::Configuration.new.public_stylesheets
+  end
+
+  test "public_stylesheets wraps a lone value in an array" do
+    config = Upright::Configuration.new
+    config.public_stylesheets = "upright/theme"
+    assert_equal [ "upright/theme" ], config.public_stylesheets
+  end
+
+  test "upright_stylesheet_link_tag renders only the engine's stylesheets by default" do
+    hrefs = upright_stylesheet_link_tag.scan(/href="([^"]+)"/).flatten
+
+    assert hrefs.any? { |h| h.include?("/upright/base") }
+    assert_equal 1, hrefs.count { |h| h.include?("/upright/reset") }
+  end
+
+  test "upright_stylesheet_link_tag appends configured public stylesheets after the engine's" do
+    # upright/theme is a dummy-app fixture (test/dummy/app/assets/stylesheets),
+    # standing in for a host app's theme override.
+    Upright.configuration.stubs(:public_stylesheets).returns([ "upright/theme" ])
+
+    hrefs = upright_stylesheet_link_tag.scan(/href="([^"]+)"/).flatten
+
+    assert hrefs.any? { |h| h.include?("/upright/base") }, "engine stylesheets still present"
+    assert_match %r{/upright/theme}, hrefs.last, "host override loads last"
+  end
+end

--- a/test/helpers/upright/public/services_helper_test.rb
+++ b/test/helpers/upright/public/services_helper_test.rb
@@ -15,8 +15,9 @@ class Upright::Public::ServicesHelperTest < ActionView::TestCase
     assert_equal "99.999%", uptime_percentage_label(fractions)
   end
 
-  test "trailing zeros are trimmed" do
-    assert_equal "99.5%", uptime_percentage_label([ 0.995 ])
+  test "always pads to three decimals below 100%" do
+    assert_equal "99.500%", uptime_percentage_label([ 0.995 ])
+    assert_equal "99.800%", uptime_percentage_label([ 0.998 ])
   end
 
   test "floors rather than rounds to three decimals" do


### PR DESCRIPTION
## What & why

The public status page shipped a fixed design with no way for a host app to rebrand it. Two things blocked overrides:

- `upright_stylesheet_link_tag` globbed **only** the engine's own stylesheet dir, so any host CSS was never loaded.
- The public layout was a bare `<main>` with no header/footer, so adding a logo meant copying the whole layout (and losing future engine updates to it).

This adds two host-agnostic hooks so a host app can theme the page without forking it.

## Changes

- **`Upright.configuration.public_stylesheets`** (Array of Propshaft logical names, default `[]`). `upright_stylesheet_link_tag` emits the engine's `upright/*.css` first, then these — so a host theme loads **last** and wins the cascade.
- **Overridable `_branding` / `_footer` layout slots** in `layouts/upright/public.html.erb`, with minimal generic defaults (`service_name` wordmark / "Powered by Upright"). Hosts override by placing their own partial at the same view path (standard Rails engine view precedence).
- Base `.status-header` / `.status-footer` styles using existing design tokens.
- **Uptime %** now always shows three decimals below 100% (`99.990%`, `99.800%`) and a bare `100%` for a flawless window (floored, so a real outage never reads as 100%).

## Tests

- New `application_helper_test` asserts engine sheets load before host-configured ones (dummy-app `upright/theme.css` fixture demonstrates the mechanism).
- Updated the uptime helper test for the always-3-decimals behavior.
- Public integration + helper tests green; RuboCop clean.

No host-specific (37signals) references — all branding lives in the host app, which consumes these hooks in a follow-up PR.