### PR TITLE
Serve Prometheus and Alertmanager per site, not just on app

### DIFF
--- a/README.md
+++ b/README.md
@@ -122,6 +122,7 @@ shared:
       country: NL
       geohash: u17982
       provider: digitalocean
+      stores_metrics: true
 
     - code: sfo
       city: San Francisco
@@ -131,6 +132,8 @@ shared:
 ```
 
 Each site node identifies itself via the `SITE_SUBDOMAIN` environment variable, configured in your Kamal deploy.yml.
+
+`stores_metrics` marks the sites running a local Prometheus and Alertmanager. Those sites accept metric writes and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others still readable; probe-only sites serve neither. Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token` (`PROMETHEUS_OTLP_TOKEN` by default) instead of an admin session.
 
 ### Authentication
 

--- a/app/assets/stylesheets/upright/header.css
+++ b/app/assets/stylesheets/upright/header.css
@@ -71,6 +71,11 @@
     &.active {
       color: var(--color-positive);
     }
+
+    &.unavailable {
+      color: var(--color-ink-light);
+      cursor: help;
+    }
   }
 
   .header__divider {

--- a/app/controllers/concerns/upright/authentication.rb
+++ b/app/controllers/concerns/upright/authentication.rb
@@ -11,6 +11,7 @@ module Upright::Authentication
       if session[:user_info].present?
         Upright::Current.user = Upright::User.new(session[:user_info])
       else
+        session[:return_to] = request.url if request.get?
         redirect_to new_admin_session_url(default_url_options.merge(subdomain: Upright.configuration.global_subdomain)), allow_other_host: true
       end
     end

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -1,0 +1,18 @@
+module Upright::ProxyAuthentication
+  extend ActiveSupport::Concern
+
+  private
+    def authenticate_user
+      if request.authorization.present?
+        authenticate_proxy_token
+      else
+        super
+      end
+    end
+
+    def authenticate_proxy_token
+      authenticate_or_request_with_http_token do |token|
+        ActiveSupport::SecurityUtils.secure_compare(token, Upright.configuration.proxy_token.to_s)
+      end
+    end
+end

--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -1,4 +1,6 @@
 class Upright::AlertmanagerProxyController < Upright::ApplicationController
+  include Upright::ProxyAuthentication
+
   skip_forgery_protection
 
   def show

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -1,8 +1,10 @@
 class Upright::PrometheusProxyController < Upright::ApplicationController
+  include Upright::ProxyAuthentication
+
   skip_forgery_protection
 
   skip_before_action :authenticate_user, only: :otlp
-  before_action :authenticate_otlp_token, only: :otlp
+  before_action :authenticate_proxy_token, only: :otlp
 
   UNSUPPORTED_PATHS = %w[/api/v1/notifications]
 
@@ -47,12 +49,6 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
     def prometheus_connection
       @prometheus_connection ||= Faraday.new(url: Upright.configuration.prometheus_url) do |f|
         f.options.timeout = 30
-      end
-    end
-
-    def authenticate_otlp_token
-      authenticate_or_request_with_http_token do |token|
-        ActiveSupport::SecurityUtils.secure_compare(token, ENV.fetch("PROMETHEUS_OTLP_TOKEN", ""))
       end
     end
 end

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -8,10 +8,11 @@ class Upright::SessionsController < Upright::ApplicationController
   end
 
   def create
+    return_to = session[:return_to]
     reset_session
     user = Upright::User.from_omniauth(request.env["omniauth.auth"])
     session[:user_info] = { email: user.email, name: user.name }
-    redirect_to upright.root_path
+    redirect_to return_to || upright.root_path, allow_other_host: true
   end
 
   def destroy

--- a/app/helpers/upright/application_helper.rb
+++ b/app/helpers/upright/application_helper.rb
@@ -7,6 +7,18 @@ module Upright::ApplicationHelper
     "#{country_flag(site.country)} #{site.city}"
   end
 
+  def metrics_subdomain
+    if Upright::Current.site.nil? || metrics_sites.none?
+      Upright.configuration.global_subdomain
+    elsif Upright::Current.site.stores_metrics?
+      Upright::Current.site.code
+    end
+  end
+
+  def metrics_sites_sentence
+    metrics_sites.map(&:city).to_sentence
+  end
+
   def page_title_tag(app_name = "Upright")
     tag.title [ @page_title, app_name ].compact.join(" · ")
   end
@@ -18,6 +30,10 @@ module Upright::ApplicationHelper
   end
 
   private
+
+  def metrics_sites
+    Upright.sites.select(&:stores_metrics?)
+  end
 
   def country_flag(country_code)
     country_code&.upcase&.gsub(/[A-Z]/) { |c| (c.ord + 0x1F1A5).chr(Encoding::UTF_8) }

--- a/app/views/layouts/upright/_header.html.erb
+++ b/app/views/layouts/upright/_header.html.erb
@@ -17,8 +17,14 @@
     <span class="header__divider"></span>
     <%= link_to "Jobs", upright.jobs_url(subdomain: current_or_default_site.code), class: "header__link" %>
     <span class="header__divider"></span>
-    <%= link_to "Prometheus", upright.prometheus_url(subdomain: Upright.configuration.global_subdomain), class: "header__link" %>
-    <%= link_to "Alertmanager", upright.alertmanager_url(subdomain: Upright.configuration.global_subdomain), class: "header__link" %>
+    <% if metrics_subdomain %>
+      <%= link_to "Prometheus", upright.prometheus_url(subdomain: metrics_subdomain), class: "header__link" %>
+      <%= link_to "Alertmanager", upright.alertmanager_url(subdomain: metrics_subdomain), class: "header__link" %>
+    <% else %>
+      <% available_on = "Available on #{metrics_sites_sentence}" %>
+      <%= tag.span "Prometheus", class: "header__link unavailable", title: available_on %>
+      <%= tag.span "Alertmanager", class: "header__link unavailable", title: available_on %>
+    <% end %>
   </nav>
 
   <div class="header__user">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,8 @@
 Upright::Engine.routes.draw do
-  global_subdomain = ->(req) { Upright.configuration.global_subdomain == req.subdomain }
-  site_subdomain   = ->(req) { Upright.configuration.site_subdomains.include?(req.subdomain) }
-  public_status    = ->(req) {
+  global_subdomain  = ->(req) { Upright.configuration.global_subdomain == req.subdomain }
+  site_subdomain    = ->(req) { Upright.configuration.site_subdomains.include?(req.subdomain) }
+  metrics_subdomain = ->(req) { global_subdomain.call(req) || Upright.find_site(req.subdomain)&.stores_metrics? }
+  public_status     = ->(req) {
     Upright.configuration.public_status_enabled &&
       req.subdomain == Upright.configuration.public_status_subdomain
   }
@@ -20,7 +21,9 @@ Upright::Engine.routes.draw do
     resources :incidents do
       resources :updates, only: :create, controller: "incidents/updates"
     end
+  end
 
+  constraints metrics_subdomain do
     scope :framed do
       resource :prometheus,   only: :show, controller: :prometheus_proxy
       resource :alertmanager, only: :show, controller: :alertmanager_proxy

--- a/lib/generators/upright/install/templates/sites.yml
+++ b/lib/generators/upright/install/templates/sites.yml
@@ -8,6 +8,7 @@ shared:
       city: London
       country: GB
       geohash: gcpvj0
+      stores_metrics: true
 
 # Multi-site example:
 #
@@ -18,6 +19,7 @@ shared:
 #       country: NL
 #       geohash: u17982
 #       provider: digitalocean
+#       stores_metrics: true
 #
 #     - code: nyc
 #       city: New York City

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -36,6 +36,8 @@ class Upright::Configuration
   attr_accessor :prometheus_url
   attr_accessor :alert_webhook_url
 
+  attr_writer :proxy_token
+
   # Probe types
   attr_reader :probe_types
 
@@ -112,6 +114,10 @@ class Upright::Configuration
 
   def prometheus_url
     @prometheus_url || ENV.fetch("PROMETHEUS_URL", "http://localhost:9090")
+  end
+
+  def proxy_token
+    @proxy_token || ENV["PROMETHEUS_OTLP_TOKEN"]
   end
 
   def video_storage_dir

--- a/lib/upright/site.rb
+++ b/lib/upright/site.rb
@@ -2,13 +2,18 @@ module Upright
   class Site
     attr_reader :code, :city, :country, :geohash, :stagger_index
 
-    def initialize(code:, city: nil, country: nil, geohash: nil, provider: nil, stagger_index: 0)
+    def initialize(code:, city: nil, country: nil, geohash: nil, provider: nil, stores_metrics: false, stagger_index: 0)
       @code = code.to_sym
       @city = city
       @country = country
       @geohash = geohash
       @provider = provider
+      @stores_metrics = stores_metrics
       @stagger_index = stagger_index
+    end
+
+    def stores_metrics?
+      @stores_metrics
     end
 
     def host

--- a/test/dummy/config/sites.yml
+++ b/test/dummy/config/sites.yml
@@ -5,6 +5,7 @@ shared:
       country: NL
       geohash: u17982
       provider: digitalocean
+      stores_metrics: true
 
     - code: nyc
       city: New York City

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -16,6 +16,36 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "proxies at a site that stores metrics" do
+    stub_request(:get, "http://localhost:9093/api/v2/status").to_return(status: 200, body: "{}")
+    sign_in
+    on_subdomain :ams
+
+    get "/alertmanager/api/v2/status"
+
+    assert_response :success
+  end
+
+  test "token stands in for a session" do
+    stub_request(:get, "http://localhost:9093/api/v2/status").to_return(status: 200, body: "{}")
+    on_subdomain :ams
+
+    with_env("PROMETHEUS_OTLP_TOKEN" => "test-token") do
+      get "/alertmanager/api/v2/status", headers: { "Authorization" => "Bearer test-token" }
+    end
+
+    assert_response :success
+  end
+
+  test "not routable at a probe-only site" do
+    sign_in
+    on_subdomain :nyc
+
+    get "/alertmanager"
+
+    assert_response :not_found
+  end
+
   test "proxies POST body to alertmanager" do
     silence_json = { matchers: [ { name: "alertname", value: "TestAlert", isRegex: false, isEqual: true } ], comment: "test" }.to_json
 

--- a/test/integration/probe_results_controller_test.rb
+++ b/test/integration/probe_results_controller_test.rb
@@ -11,6 +11,32 @@ class ProbeResultsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "nav links Prometheus and Alertmanager at a site that stores metrics" do
+    get upright.site_root_path
+
+    assert_select "nav a[href=?]", upright.prometheus_url(subdomain: "ams"), text: "Prometheus"
+    assert_select "nav a[href=?]", upright.alertmanager_url(subdomain: "ams"), text: "Alertmanager"
+  end
+
+  test "nav greys out Prometheus and Alertmanager at a probe-only site" do
+    on_subdomain "nyc"
+
+    get upright.site_root_path
+
+    assert_select "nav a", text: "Prometheus", count: 0
+    assert_select "nav span.unavailable[title=?]", "Available on Amsterdam", text: "Prometheus"
+    assert_select "nav span.unavailable[title=?]", "Available on Amsterdam", text: "Alertmanager"
+  end
+
+  test "nav falls back to the global subdomain when no site claims metrics" do
+    probe_only_sites = Upright.sites.reject(&:stores_metrics?)
+    Upright.stubs(:sites).returns(probe_only_sites)
+
+    get upright.site_root_path
+
+    assert_select "nav a[href=?]", upright.prometheus_url(subdomain: "app"), text: "Prometheus"
+  end
+
   test "renders filter links for all registered probe types" do
     get upright.site_root_path
     assert_response :success

--- a/test/integration/prometheus_proxy_controller_test.rb
+++ b/test/integration/prometheus_proxy_controller_test.rb
@@ -25,6 +25,52 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
   end
 
+  test "proxies at a site that stores metrics" do
+    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+    sign_in
+    on_subdomain :ams
+
+    get "/prometheus/graph"
+
+    assert_response :success
+  end
+
+  test "accepts OTLP writes at a site that stores metrics" do
+    stub_request(:post, "http://localhost:9090/api/v1/otlp/v1/metrics").to_return(status: 200)
+    on_subdomain :ams
+
+    post "/prometheus/api/v1/otlp/v1/metrics",
+      headers: { "Authorization" => "Bearer test-token", "Content-Type" => "application/x-protobuf" }
+
+    assert_response :success
+  end
+
+  test "token stands in for a session, so a peer site can be read" do
+    stub_request(:get, "http://localhost:9090/api/v1/query?query=up").to_return(status: 200, body: "{}")
+    on_subdomain :ams
+
+    get "/prometheus/api/v1/query?query=up", headers: { "Authorization" => "Bearer test-token" }
+
+    assert_response :success
+  end
+
+  test "rejects a bad token instead of redirecting to the login" do
+    on_subdomain :ams
+
+    get "/prometheus/api/v1/query?query=up", headers: { "Authorization" => "Bearer wrong-token" }
+
+    assert_response :unauthorized
+  end
+
+  test "not routable at a probe-only site" do
+    sign_in
+    on_subdomain :nyc
+
+    get "/prometheus/graph"
+
+    assert_response :not_found
+  end
+
   test "proxy requires authentication" do
     get "/prometheus/graph"
 

--- a/test/integration/sessions_controller_test.rb
+++ b/test/integration/sessions_controller_test.rb
@@ -21,6 +21,15 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to upright.new_admin_session_url(subdomain: "app")
   end
 
+  test "returns to the page that sent you to the login" do
+    on_subdomain "ams"
+    get upright.prometheus_path
+
+    sign_in
+
+    assert_redirected_to "http://ams.#{Upright.configuration.hostname}#{upright.prometheus_path}"
+  end
+
   test "session routes not accessible from site subdomain" do
     on_subdomain "ams"
     get upright.new_admin_session_path


### PR DESCRIPTION
Prometheus and Alertmanager run per host, but their proxies only answered on `app.` — which resolves to one box, so losing it took the peer's Prometheus with it.

Sites now declare `stores_metrics: true`. The proxies and OTLP ingest answer on those subdomains as well as `app.`, and probe-only sites 404. Both proxies accept the token when one is offered and the admin session otherwise, so a job can read a peer. The nav follows the current site, greying out both links where there's no Prometheus.