### PR TITLE
Add changelog for unreleased changes since v0.3.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,24 @@
 # Changelog
 
+## Unreleased
+
+- Add public status pages: live status, 90-day history, and an RSS feed (#79)
+- Add incidents and scheduled maintenance, with a public timeline and impact banner (#102)
+- Record who created and updated each incident (#105)
+- Let host apps override the public status page's stylesheets and views (#109)
+- Split rollups into a `persistent` database so status history outlives a site's probe data — host apps need a `persistent` connection in `database.yml` (#87)
+- Serve the Prometheus and Alertmanager proxies on any site declaring `stores_metrics: true` rather than the app subdomain alone, and accept a token in place of an admin session (#114)
+- Scope Prometheus queries by environment, so staging stops reporting production data (#95)
+- Use HTTPS and secure cookies in every deployed environment, not just production (#89)
+- Show an environment badge in the header outside production (#90)
+- Make the services definition path env-overridable (#97)
+- Launch Playwright directly instead of through a remote server (#55)
+- Carry `alert_severity` through the generated alert rules so routing keeps the label (#58)
+- Give probe result durations sub-second precision (#96)
+- Make service descriptions optional, and improve the uptime tooltips (#99)
+- Show uptime to three decimals; never round an outage up to 100% (#98)
+- Purge stale probe results without enqueuing a job per attachment (#69)
+
 ## v0.3.0
 
 - Allow host apps to register custom probe types via `config.probe_types.register` (#42)


### PR DESCRIPTION
16 entries covering everything merged since the v0.3.0 tag, plus #114 which is still open.

Dependabot and CI-only PRs (#86, #94, #104, #64) are left out, matching the v0.3.0 section. Two entries name the host action they require: the `persistent` database (#87) and the `stores_metrics` flag (#114).

Worth merging #114 first, or dropping its line — otherwise the changelog briefly lists something that isn't in main.