### PR TITLE
Export the metrics failover alerting needs

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,8 @@ shared:
 
 Each site node identifies itself via the `SITE_SUBDOMAIN` environment variable, configured in your Kamal deploy.yml.
 
+`primary` marks the site that serves the app and status hostnames and runs the singleton jobs — the ones writing the shared `persistent` database, which must run in exactly one place. Gate them in `config/recurring.yml` with `Upright.current_site&.primary?`. Every site exports `upright_primary_site` (1 on the primary, 0 elsewhere), so alerting can find the primary without hardcoding a site code, and notice when it stops reporting.
+
 `stores_metrics` marks the sites running a local Prometheus and Alertmanager. Those sites accept metric writes and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others still readable; probe-only sites serve neither. Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token` (`PROMETHEUS_OTLP_TOKEN` by default) instead of an admin session.
 
 ### Authentication

--- a/app/jobs/upright/health_metrics_job.rb
+++ b/app/jobs/upright/health_metrics_job.rb
@@ -1,0 +1,14 @@
+class Upright::HealthMetricsJob < Upright::ApplicationJob
+  queue_as :default
+
+  def perform
+    Yabeda.upright_primary_site.set({}, Upright.current_site&.primary? ? 1 : 0)
+
+    if Upright::PersistentRecord.up?
+      Yabeda.upright_persistent_db_up.set({}, 1)
+      Upright::Rollups::ProbeRollup.export_metrics
+    else
+      Yabeda.upright_persistent_db_up.set({}, 0)
+    end
+  end
+end

--- a/app/models/upright/persistent_record.rb
+++ b/app/models/upright/persistent_record.rb
@@ -3,4 +3,10 @@ class Upright::PersistentRecord < ActiveRecord::Base
   self.abstract_class = true
 
   connects_to database: { writing: :persistent, reading: :persistent }
+
+  def self.up?
+    with_connection { |connection| connection.select_value("SELECT 1") }.present?
+  rescue ActiveRecord::ActiveRecordError
+    false
+  end
 end

--- a/app/models/upright/rollups/probe_rollup.rb
+++ b/app/models/upright/rollups/probe_rollup.rb
@@ -25,6 +25,12 @@ class Upright::Rollups::ProbeRollup < Upright::PersistentRecord
     end
   end
 
+  def self.export_metrics
+    if (last_run = maximum(:created_at))
+      Yabeda.upright_rollup_last_run_timestamp_seconds.set({}, last_run.to_i)
+    end
+  end
+
   def probe_key
     [ probe_name, probe_type, probe_target ]
   end

--- a/lib/generators/upright/install/templates/recurring.yml
+++ b/lib/generators/upright/install/templates/recurring.yml
@@ -23,3 +23,7 @@ production:
   cleanup_stale_probe_results:
     command: "Upright::ProbeResult.cleanup_stale"
     schedule: every hour at minute 30
+
+  health_metrics:
+    class: "Upright::HealthMetricsJob"
+    schedule: every minute

--- a/lib/generators/upright/install/templates/sites.yml
+++ b/lib/generators/upright/install/templates/sites.yml
@@ -9,6 +9,7 @@ shared:
       country: GB
       geohash: gcpvj0
       stores_metrics: true
+      primary: true
 
 # Multi-site example:
 #
@@ -20,6 +21,7 @@ shared:
 #       geohash: u17982
 #       provider: digitalocean
 #       stores_metrics: true
+#       primary: true
 #
 #     - code: nyc
 #       city: New York City

--- a/lib/upright.rb
+++ b/lib/upright.rb
@@ -63,6 +63,10 @@ module Upright
       find_site(ENV["SITE_SUBDOMAIN"]) || sites.first
     end
 
+    def primary_site
+      sites.find(&:primary?)
+    end
+
     private
       def load_sites
         sites_config_path = Rails.root.join("config/sites.yml")

--- a/lib/upright/metrics.rb
+++ b/lib/upright/metrics.rb
@@ -60,6 +60,21 @@ module Upright::Metrics
               comment: "Whether a service is under active maintenance (1 = yes, 0 = no)",
               aggregation: :most_recent,
               tags: %i[probe_service]
+
+            gauge :primary_site,
+              comment: "Whether this site is the primary (1 = yes, 0 = no)",
+              aggregation: :most_recent,
+              tags: []
+
+            gauge :persistent_db_up,
+              comment: "Whether the persistent database answers (1 = yes, 0 = no)",
+              aggregation: :most_recent,
+              tags: []
+
+            gauge :rollup_last_run_timestamp_seconds,
+              comment: "Unix time of the most recently written daily rollup",
+              aggregation: :max,
+              tags: []
           end
         end
       end

--- a/lib/upright/site.rb
+++ b/lib/upright/site.rb
@@ -2,18 +2,23 @@ module Upright
   class Site
     attr_reader :code, :city, :country, :geohash, :stagger_index
 
-    def initialize(code:, city: nil, country: nil, geohash: nil, provider: nil, stores_metrics: false, stagger_index: 0)
+    def initialize(code:, city: nil, country: nil, geohash: nil, provider: nil, stores_metrics: false, primary: false, stagger_index: 0)
       @code = code.to_sym
       @city = city
       @country = country
       @geohash = geohash
       @provider = provider
       @stores_metrics = stores_metrics
+      @primary = primary
       @stagger_index = stagger_index
     end
 
     def stores_metrics?
       @stores_metrics
+    end
+
+    def primary?
+      @primary
     end
 
     def host

--- a/test/dummy/config/sites.yml
+++ b/test/dummy/config/sites.yml
@@ -6,6 +6,7 @@ shared:
       geohash: u17982
       provider: digitalocean
       stores_metrics: true
+      primary: true
 
     - code: nyc
       city: New York City

--- a/test/jobs/upright/health_metrics_job_test.rb
+++ b/test/jobs/upright/health_metrics_job_test.rb
@@ -1,0 +1,52 @@
+require "test_helper"
+
+class Upright::HealthMetricsJobTest < ActiveSupport::TestCase
+  test "reports 1 for primary_site on the primary" do
+    with_env("SITE_SUBDOMAIN" => "ams") do
+      Upright::HealthMetricsJob.perform_now
+    end
+
+    assert_equal 1, yabeda_gauge_value(:primary_site)
+  end
+
+  test "reports 0 for primary_site elsewhere" do
+    with_env("SITE_SUBDOMAIN" => "nyc") do
+      Upright::HealthMetricsJob.perform_now
+    end
+
+    assert_equal 0, yabeda_gauge_value(:primary_site)
+  end
+
+  test "reports the persistent database as up" do
+    Upright::HealthMetricsJob.perform_now
+
+    assert_equal 1, yabeda_gauge_value(:persistent_db_up)
+  end
+
+  test "reports the persistent database as down without failing the other metrics" do
+    Upright::PersistentRecord.stubs(:up?).returns(false)
+
+    Upright::HealthMetricsJob.perform_now
+
+    assert_equal 0, yabeda_gauge_value(:persistent_db_up)
+    assert_equal 1, yabeda_gauge_value(:primary_site)
+  end
+
+  test "reports the most recent rollup as the last run" do
+    rollup = upright_rollups_probe_rollups(:example_web_may_11)
+
+    Upright::HealthMetricsJob.perform_now
+
+    assert_equal Upright::Rollups::ProbeRollup.maximum(:created_at).to_i,
+      yabeda_gauge_value(:rollup_last_run_timestamp_seconds)
+    assert_operator yabeda_gauge_value(:rollup_last_run_timestamp_seconds), :>=, rollup.created_at.to_i
+  end
+
+  test "leaves the last run unset when nothing has been rolled up" do
+    Upright::Rollups::ProbeRollup.delete_all
+
+    Upright::HealthMetricsJob.perform_now
+
+    assert_nil yabeda_gauge_value(:rollup_last_run_timestamp_seconds)
+  end
+end


### PR DESCRIPTION
Three gauges, exported from every site by `HealthMetricsJob` so they survive losing the site they describe.

`upright_primary_site` — 1 on the primary, 0 elsewhere, so a rule can find the primary without hardcoding a site code and notice when it stops reporting. Sites declare `primary: true`; until now hosts encoded this themselves, which in practice meant a site code hardcoded in `recurring.yml`. `Upright.current_site&.primary?` replaces that.

`upright_persistent_db_up` — the current single point of failure, unmonitored until now. Set before the rollup export so a database outage still reports 0 rather than failing the job on the way past.

`upright_rollup_last_run_timestamp_seconds` — read from the newest rollup row, not stamped when the job finishes. A job-set gauge lives in the jobs container's `DirectFileStore`, so it would reset on every deploy and flap. Granularity is a day, which suits "no rollup landed"; catching a stopped cron sooner would want a heartbeat row, which needs a persistent migration.

Prerequisite for the three alerts in the failover plan: `UprightPrimarySiteDown`, `UprightPersistentDBUnreachable`, `UprightRollupStale`.

242 tests pass, rubocop clean. Six new tests cover both `primary_site` values, the database up and down paths (asserting the other gauges still report when it's down), and the last-run timestamp present and absent. Flipping the dummy site's `primary` flag off fails two of them, so they're testing the flag rather than the default.