### PR TITLE
Roll up from whichever site saw the day

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Roll up daily uptime from every `stores_metrics` site, preferring the best-covered instance per probe; skip and report probe-days below `config.rollup_minimum_coverage` instead of averaging a gappy window; correct rollups in place and backfill a week (#121). `upright:probe_down_fraction` now falls back to zero when no region is down, which the coverage count depends on; rules predating this need the same fallback, or `config.rollup_minimum_coverage = 0`
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)
 - Add incidents and scheduled maintenance, with a public timeline and impact banner (#102)

--- a/README.md
+++ b/README.md
@@ -134,19 +134,7 @@ shared:
 
 Each site node identifies itself via the `SITE_SUBDOMAIN` environment variable, configured in your Kamal deploy.yml.
 
-`primary` marks the site that serves the app and status hostnames and runs the singleton jobs — the ones writing the shared `persistent` database, which must run in exactly one place. Gate them in `config/recurring.yml` with `Upright.current_site&.primary?`. Declaring two primaries raises on boot. Declaring none is also legal, but that gate is then false everywhere, so nothing runs the singletons — if you use it, flag exactly one site. A host with its own gate keeps whatever behaviour it already had; the flag doesn't override it.
-
-Every site exports `upright_primary_site` (1 on the primary, 0 elsewhere), so alerting can find the primary without hardcoding a site code and notice when it stops reporting. Sites that `stores_metrics` additionally export `upright_persistent_db_up` and `upright_rollup_last_run_timestamp_seconds`, so both survive losing the primary. Probe-only sites skip that check: they aren't expected to reach the persistent database, and where they're firewalled off a connection attempt hangs rather than being refused, tying up a worker every run. So grant a site the persistent database alongside its Prometheus, or leave the flag off. `Upright::HealthMetricsJob` refreshes all three, so schedule it on every site — new installs get it from the generator, existing ones need it adding:
-
-```yaml
-# config/recurring.yml — under each environment you run, as with every other task
-production:
-  health_metrics:
-    class: "Upright::HealthMetricsJob"
-    schedule: every minute
-```
-
-`stores_metrics` marks the sites running a local Prometheus and Alertmanager. Those sites accept metric writes and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others still readable; probe-only sites serve neither. Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token` (`PROMETHEUS_OTLP_TOKEN` by default) instead of an admin session.
+Two optional flags give a site a role beyond running probes: `primary` serves the app and status hostnames and runs the jobs writing the shared database, and `stores_metrics` runs a local Prometheus and Alertmanager. See [Sites and their roles](https://github.com/basecamp/upright/blob/main/docs/sites.md) for what each one changes, the health metrics every site exports, and how daily rollups read across them.
 
 ### Authentication
 

--- a/app/jobs/upright/rollups/daily_aggregation_job.rb
+++ b/app/jobs/upright/rollups/daily_aggregation_job.rb
@@ -4,9 +4,11 @@ class Upright::Rollups::DailyAggregationJob < Upright::ApplicationJob
   # Aggregates daily rollups for completed days only — today is still in progress
   # and is represented live by Service#live_status, so persisting a half-day
   # rollup would just produce a stale value the rest of the day.
-  def perform(past: 1.day)
-    (past.ago.to_date..Date.yesterday).each do |day|
+  def perform(past: 7.days)
+    left_unwritten = (past.ago.to_date..Date.yesterday).flat_map do |day|
       Upright::Rollups::ProbeRollup.rollup_day(day)
     end
+
+    Yabeda.upright_rollup_skipped_probes.set({}, left_unwritten.size)
   end
 end

--- a/app/models/upright/rollups/daily_uptime.rb
+++ b/app/models/upright/rollups/daily_uptime.rb
@@ -1,0 +1,28 @@
+class Upright::Rollups::DailyUptime
+  attr_reader :day
+
+  def initialize(day, sites: Upright.sites.select(&:stores_metrics?))
+    @day, @sites = day, sites
+  end
+
+  def covered
+    probe_uptimes.select(&:covered?)
+  end
+
+  def gappy
+    probe_uptimes.reject(&:covered?)
+  end
+
+  private
+    def probe_uptimes
+      @probe_uptimes ||= best_covered_per_probe(reported_uptimes)
+    end
+
+    def best_covered_per_probe(probe_uptimes)
+      probe_uptimes.group_by(&:probe_key).values.map { |reported| reported.max_by(&:coverage_fraction) }
+    end
+
+    def reported_uptimes
+      @sites.flat_map { |site| Upright::Rollups::SiteUptime.new(site, on: day).probe_uptimes }
+    end
+end

--- a/app/models/upright/rollups/probe_rollup.rb
+++ b/app/models/upright/rollups/probe_rollup.rb
@@ -9,20 +9,32 @@ class Upright::Rollups::ProbeRollup < Upright::PersistentRecord
   scope :for_service, ->(code) { where(probe_service: code) if code.present? }
   scope :for_probe, ->(name) { where(probe_name: name) if name.present? }
 
-  PROMETHEUS_METRIC = "upright:probe_uptime_daily"
-
   def self.rollup_day(day)
-    fetch_uptime_for(day).each do |probe_uptime|
-      find_or_create_by(
-        probe_name:   probe_uptime.fetch(:probe_name),
-        probe_type:   probe_uptime[:probe_type],
-        probe_target: probe_uptime[:probe_target],
-        period_start: day.beginning_of_day
-      ) do |rollup|
-        rollup.probe_service   = probe_uptime[:probe_service]
-        rollup.uptime_fraction = probe_uptime.fetch(:uptime_fraction)
-      end
+    uptime = Upright::Rollups::DailyUptime.new(day)
+
+    uptime.covered.each { |probe_uptime| record probe_uptime, on: day }
+
+    uptime.gappy.tap do |left_unwritten|
+      Rails.logger.warn thin_coverage_warning(left_unwritten, on: day) if left_unwritten.any?
     end
+  end
+
+  def self.thin_coverage_warning(probe_uptimes, on:)
+    "[upright] #{on}: left #{probe_uptimes.size} rollups unwritten below #{Upright.configuration.rollup_minimum_coverage} coverage (#{probe_uptimes.map(&:probe_name).uniq.join(', ')})"
+  end
+  private_class_method :thin_coverage_warning
+
+  def self.record(probe_uptime, on:)
+    rollup = find_or_initialize_by(
+      probe_name:   probe_uptime.probe_name,
+      probe_type:   probe_uptime.probe_type,
+      probe_target: probe_uptime.probe_target,
+      period_start: on.beginning_of_day
+    )
+
+    rollup.probe_service   = probe_uptime.probe_service
+    rollup.uptime_fraction = probe_uptime.uptime_fraction
+    rollup.save!
   end
 
   def self.export_metrics
@@ -33,26 +45,6 @@ class Upright::Rollups::ProbeRollup < Upright::PersistentRecord
 
   def probe_key
     [ probe_name, probe_type, probe_target ]
-  end
-
-  def self.fetch_uptime_for(day)
-    query_time = [ day.end_of_day, Time.current ].min
-
-    response = Upright.prometheus_client.query(query: uptime_query, time: query_time.iso8601).deep_symbolize_keys
-
-    Array(response[:result]).map do |series|
-      {
-        probe_name:      series.dig(:metric, :name),
-        probe_type:      series.dig(:metric, :type),
-        probe_target:    series.dig(:metric, :probe_target),
-        probe_service:   series.dig(:metric, :probe_service).presence,
-        uptime_fraction: series.dig(:value, 1).to_f
-      }
-    end
-  end
-
-  def self.uptime_query
-    %(#{PROMETHEUS_METRIC}{environment="#{Rails.env}"})
   end
 
   def service

--- a/app/models/upright/rollups/probe_uptime.rb
+++ b/app/models/upright/rollups/probe_uptime.rb
@@ -1,0 +1,9 @@
+class Upright::Rollups::ProbeUptime < Data.define(:probe_name, :probe_type, :probe_target, :probe_service, :uptime_fraction, :coverage_fraction)
+  def probe_key
+    [ probe_name, probe_type, probe_target ]
+  end
+
+  def covered?
+    coverage_fraction >= Upright.configuration.rollup_minimum_coverage
+  end
+end

--- a/app/models/upright/rollups/site_uptime.rb
+++ b/app/models/upright/rollups/site_uptime.rb
@@ -1,0 +1,75 @@
+class Upright::Rollups::SiteUptime
+  UPTIME_METRIC   = "upright:probe_uptime_daily"
+  COVERAGE_METRIC = "upright:probe_down_fraction"
+
+  attr_reader :site, :day
+
+  def initialize(site, on:)
+    @site, @day = site, on
+  end
+
+  def probe_uptimes
+    uptime_series.map do |metric, uptime|
+      Upright::Rollups::ProbeUptime.new(
+        probe_name:        metric[:name],
+        probe_type:        metric[:type],
+        probe_target:      metric[:probe_target],
+        probe_service:     metric[:probe_service].presence,
+        uptime_fraction:   uptime,
+        coverage_fraction: coverage_for(metric)
+      )
+    end
+  rescue StandardError => error
+    nothing_reported because: error
+  end
+
+  private
+    def nothing_reported(because:)
+      Rails.logger.warn "[upright] #{site.code} Prometheus unavailable for the #{day} rollup: #{because.class}: #{because.message}"
+      []
+    end
+
+    def uptime_series
+      series_for uptime_query
+    end
+
+    def coverage_for(metric)
+      [ coverage.fetch(probe_key_for(metric), 0.0), 1.0 ].min
+    end
+
+    def coverage
+      @coverage ||= series_for(coverage_query).to_h do |metric, samples|
+        [ probe_key_for(metric), samples / expected_samples ]
+      end
+    end
+
+    def series_for(query)
+      values_by_metric site.prometheus_client.query(query: query, time: queried_at.iso8601)
+    end
+
+    def values_by_metric(response)
+      Array(response.deep_symbolize_keys[:result]).map do |series|
+        [ series[:metric], series.dig(:value, 1).to_f ]
+      end
+    end
+
+    def queried_at
+      [ day.end_of_day, Time.current ].min
+    end
+
+    def expected_samples
+      1.day / Upright.configuration.rollup_evaluation_interval
+    end
+
+    def probe_key_for(metric)
+      metric.values_at(:name, :type, :probe_target)
+    end
+
+    def uptime_query
+      %(#{UPTIME_METRIC}{environment="#{Rails.env}"})
+    end
+
+    def coverage_query
+      %(count_over_time(#{COVERAGE_METRIC}{environment="#{Rails.env}"}[1d]))
+    end
+end

--- a/docs/sites.md
+++ b/docs/sites.md
@@ -1,0 +1,84 @@
+# Sites and their roles
+
+Every site runs probes. Two optional roles in `config/sites.yml` say which sites do more than that:
+
+```yaml
+shared:
+  sites:
+    - code: ams
+      city: Amsterdam
+      country: NL
+      geohash: u17982
+      provider: digitalocean
+      stores_metrics: true
+      primary: true
+
+    - code: sfo
+      city: San Francisco
+      country: US
+      geohash: 9q8yy
+      provider: hetzner
+      stores_metrics: true
+
+    - code: nyc
+      city: New York City
+      country: US
+      geohash: dr5reg
+      provider: digitalocean
+```
+
+Each site identifies itself with the `SITE_SUBDOMAIN` environment variable, set per host in your Kamal `deploy.yml`. A value naming no site in `sites.yml` refuses to boot, rather than resolving to the first site and quietly labelling that host's data as somewhere else.
+
+## primary
+
+The site serving the app and status hostnames, and running the jobs that write the shared `persistent` database: the daily rollup and the maintenance advance. Those must run in exactly one place, so gate them in `config/recurring.yml`:
+
+```yaml
+production:
+  aggregate_rollups:
+    class: "Upright::Rollups::DailyAggregationJob"
+    schedule: every hour at minute 5
+```
+
+```erb
+<% if Upright.current_site&.primary? %>
+```
+
+Declaring two primaries refuses to boot. Declaring none is legal, but that gate is then false everywhere and nothing runs those jobs, so flag exactly one site if you use it. A host gating on something of its own keeps whatever behaviour it already had.
+
+Failing over is moving the flag and deploying, then repointing DNS.
+
+## stores_metrics
+
+Sites running a local Prometheus and Alertmanager. They accept metric writes from every site's collector and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others readable. Probe-only sites serve neither, and 404 those paths rather than proxying to something that isn't there.
+
+Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token`, which defaults to `PROMETHEUS_OTLP_TOKEN`, instead of an admin session.
+
+These sites are also expected to reach the `persistent` database. Probe-only sites aren't asked to: where they're firewalled off it, a connection attempt hangs rather than being refused, which ties up a worker on every run.
+
+## Health metrics
+
+Every site exports `upright_primary_site`: 1 on the primary, 0 elsewhere. Alerting can then find the primary without hardcoding a site code, and notice when nothing claims the role.
+
+Sites that `stores_metrics` also export `upright_persistent_db_up` and `upright_rollup_last_run_timestamp_seconds`, so both survive losing the primary. The rollup timestamp is read from the newest rollup row rather than stamped when the job finishes, so it isn't reset by a deploy.
+
+`Upright::HealthMetricsJob` refreshes all of them. Schedule it on every site — new installs get it from the generator, existing ones need it adding:
+
+```yaml
+production:
+  health_metrics:
+    class: "Upright::HealthMetricsJob"
+    schedule: every minute
+```
+
+## Daily rollups
+
+`Upright::Rollups::DailyAggregationJob` writes one row per probe per completed day, which is what the public status page's history reads.
+
+It asks every `stores_metrics` site and takes each probe from whichever one covered that day best. Each holds the whole fleet's series, so each can answer for every probe; they differ only in what they were up to receive. Without that, a day spanning an outage on the site running the rollup would be averaged from a partial window and published as better than it was.
+
+A probe-day whose best coverage falls below `config.rollup_minimum_coverage` (0.9) is left unwritten and counted in `upright_rollup_skipped_probes`. Coverage counts samples of `upright:probe_down_fraction` against `config.rollup_evaluation_interval` (30 seconds), which must match the `interval` on the `upright_recording` rule group.
+
+That series has to emit for healthy probes as well as unhealthy ones for the count to mean anything. The shipped rule does, by falling back to zero when no region is down. If yours predates that, add the fallback or set `config.rollup_minimum_coverage` to 0 to write every day regardless.
+
+Rows are corrected in place, and the job reaches back a week, so a day skipped while a gap was open is rewritten once the gap closes. The coverage guard is what keeps that safe in the other direction: a thin recompute can't overwrite a day already recorded well.

--- a/lib/generators/upright/install/templates/upright.rules.yml
+++ b/lib/generators/upright/install/templates/upright.rules.yml
@@ -9,7 +9,11 @@ groups:
       # Keep probe_service so the public status page can read live status per service.
       - record: upright:probe_down_fraction
         expr: |
-          count by (name, type, probe_target, alert_severity, probe_service) (upright_probe_up == 0)
+          (
+            count by (name, type, probe_target, alert_severity, probe_service) (upright_probe_up == 0)
+            or
+            count by (name, type, probe_target, alert_severity, probe_service) (upright_probe_up) * 0
+          )
           /
           count by (name, type, probe_target, alert_severity, probe_service) (upright_probe_up)
 

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -38,6 +38,9 @@ class Upright::Configuration
 
   attr_writer :proxy_token
 
+  attr_writer :rollup_minimum_coverage
+  attr_writer :rollup_evaluation_interval
+
   # Probe types
   attr_reader :probe_types
 
@@ -118,6 +121,14 @@ class Upright::Configuration
 
   def proxy_token
     @proxy_token || ENV["PROMETHEUS_OTLP_TOKEN"]
+  end
+
+  def rollup_minimum_coverage
+    @rollup_minimum_coverage || 0.9
+  end
+
+  def rollup_evaluation_interval
+    @rollup_evaluation_interval || 30.seconds
   end
 
   def video_storage_dir

--- a/lib/upright/metrics.rb
+++ b/lib/upright/metrics.rb
@@ -71,6 +71,11 @@ module Upright::Metrics
               aggregation: :most_recent,
               tags: []
 
+            gauge :rollup_skipped_probes,
+              comment: "Probes the last rollup run left unwritten for insufficient Prometheus coverage",
+              aggregation: :most_recent,
+              tags: []
+
             gauge :rollup_last_run_timestamp_seconds,
               comment: "Unix time of the most recently written daily rollup",
               aggregation: :max,

--- a/lib/upright/site.rb
+++ b/lib/upright/site.rb
@@ -25,6 +25,14 @@ module Upright
       URI.parse(url).host
     end
 
+    def current?
+      code == Upright.current_site&.code
+    end
+
+    def prometheus_client
+      current? ? Upright.prometheus_client : peer_prometheus_client
+    end
+
     def provider
       @provider.to_s.inquiry
     end
@@ -50,6 +58,18 @@ module Upright
     end
 
     private
+      def peer_prometheus_client
+        Prometheus::ApiClient.client(url: prometheus_proxy_url, headers: proxy_authorization, options: { timeout: 30 })
+      end
+
+      def prometheus_proxy_url
+        "#{url.chomp("/")}/prometheus"
+      end
+
+      def proxy_authorization
+        { "Authorization" => "Bearer #{Upright.configuration.proxy_token}" }
+      end
+
       def coordinates
         @coordinates ||= Upright::Geohash.decode(geohash).first
       end

--- a/test/jobs/upright/rollups/daily_aggregation_job_test.rb
+++ b/test/jobs/upright/rollups/daily_aggregation_job_test.rb
@@ -3,12 +3,31 @@ require "test_helper"
 class Upright::Rollups::DailyAggregationJobTest < ActiveSupport::TestCase
   test "aggregates yesterday and earlier — today is still in progress" do
     travel_to Time.zone.local(2026, 5, 12, 14, 0) do
-      yesterday = Date.yesterday
-
-      Upright::Rollups::ProbeRollup.expects(:rollup_day).with(yesterday).once
+      Upright::Rollups::ProbeRollup.stubs(:rollup_day).returns([])
+      Upright::Rollups::ProbeRollup.expects(:rollup_day).with(Date.yesterday).once.returns([])
       Upright::Rollups::ProbeRollup.expects(:rollup_day).with(Date.current).never
 
       Upright::Rollups::DailyAggregationJob.new.perform
+    end
+  end
+
+  test "backfills a week, so a day skipped for thin coverage gets another chance" do
+    travel_to Time.zone.local(2026, 5, 12, 14, 0) do
+      (Date.new(2026, 5, 5)..Date.new(2026, 5, 11)).each do |day|
+        Upright::Rollups::ProbeRollup.expects(:rollup_day).with(day).once.returns([])
+      end
+
+      Upright::Rollups::DailyAggregationJob.new.perform
+    end
+  end
+
+  test "reports the probes it skipped" do
+    travel_to Time.zone.local(2026, 5, 12, 14, 0) do
+      Upright::Rollups::ProbeRollup.stubs(:rollup_day).returns([ thin_probe, thin_probe ])
+
+      Upright::Rollups::DailyAggregationJob.new.perform
+
+      assert_equal 14, yabeda_gauge_value(:rollup_skipped_probes)
     end
   end
 
@@ -17,6 +36,15 @@ class Upright::Rollups::DailyAggregationJobTest < ActiveSupport::TestCase
       Upright::Rollups::ProbeRollup.expects(:rollup_day).never
 
       Upright::Rollups::DailyAggregationJob.new.perform(past: 0.days)
+      assert_equal 0, yabeda_gauge_value(:rollup_skipped_probes)
     end
   end
+
+  private
+    def thin_probe
+      Upright::Rollups::ProbeUptime.new(
+        probe_name: "Thin", probe_type: "http", probe_target: "https://example.com",
+        probe_service: nil, uptime_fraction: 1.0, coverage_fraction: 0.1
+      )
+    end
 end

--- a/test/models/upright/rollups/daily_uptime_test.rb
+++ b/test/models/upright/rollups/daily_uptime_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Upright::Rollups::DailyUptimeTest < ActiveSupport::TestCase
+  setup { @day = Date.new(2026, 5, 1) }
+
+  test "takes each probe from the site that covered the day best" do
+    outage_survivor = site_reporting(uptime(probe_name: "Web", uptime_fraction: 0.82, coverage_fraction: 1.0))
+    was_itself_down = site_reporting(uptime(probe_name: "Web", uptime_fraction: 1.0, coverage_fraction: 0.1))
+
+    daily = Upright::Rollups::DailyUptime.new(@day, sites: [ was_itself_down, outage_survivor ])
+
+    assert_equal [ 0.82 ], daily.covered.map(&:uptime_fraction)
+    assert_empty daily.gappy
+  end
+
+  test "keeps distinct probes apart while coalescing" do
+    site = site_reporting(
+      uptime(probe_name: "Web", uptime_fraction: 1.0),
+      uptime(probe_name: "API", probe_target: "https://example.com/api", uptime_fraction: 0.9)
+    )
+
+    assert_equal %w[ Web API ].sort, Upright::Rollups::DailyUptime.new(@day, sites: [ site ]).covered.map(&:probe_name).sort
+  end
+
+  test "separates probes covered well enough to write from the rest" do
+    site = site_reporting(
+      uptime(probe_name: "Full", coverage_fraction: 0.95),
+      uptime(probe_name: "Thin", probe_target: "https://example.com/thin", coverage_fraction: 0.3)
+    )
+
+    daily = Upright::Rollups::DailyUptime.new(@day, sites: [ site ])
+
+    assert_equal [ "Full" ], daily.covered.map(&:probe_name)
+    assert_equal [ "Thin" ], daily.gappy.map(&:probe_name)
+  end
+
+  test "asks only the sites that keep metrics" do
+    Upright.stubs(:sites).returns([ Upright::Site.new(code: "nyc", city: "New York City"), stores_metrics_site ])
+
+    Upright::Rollups::SiteUptime.expects(:new).with(anything, on: @day).once.returns(stub(probe_uptimes: []))
+
+    Upright::Rollups::DailyUptime.new(@day).covered
+  end
+
+  private
+    def uptime(probe_name:, probe_type: "http", probe_target: "https://example.com", probe_service: "example_app", uptime_fraction: 1.0, coverage_fraction: 1.0)
+      Upright::Rollups::ProbeUptime.new(
+        probe_name: probe_name, probe_type: probe_type, probe_target: probe_target,
+        probe_service: probe_service, uptime_fraction: uptime_fraction, coverage_fraction: coverage_fraction
+      )
+    end
+
+    def site_reporting(*probe_uptimes)
+      stores_metrics_site.tap do |site|
+        Upright::Rollups::SiteUptime.stubs(:new).with(site, on: @day).returns(stub(probe_uptimes: probe_uptimes))
+      end
+    end
+
+    def stores_metrics_site
+      Upright::Site.new(code: "sfo", city: "San Francisco", stores_metrics: true)
+    end
+end

--- a/test/models/upright/rollups/probe_rollup_test.rb
+++ b/test/models/upright/rollups/probe_rollup_test.rb
@@ -17,14 +17,11 @@ class Upright::Rollups::ProbeRollupTest < ActiveSupport::TestCase
     assert_equal "major_outage", rollup.status
   end
 
-  test "rollup_day creates a rollup per probe uptime with derived status" do
+  test "rollup_day records a rollup per probe with derived status" do
     day = Date.new(2026, 5, 1)
-    probe_uptimes = [
-      { probe_name: "Web", probe_type: "http", probe_target: "https://example.com", probe_service: "example_app", uptime_fraction: 1.0 },
-      { probe_name: "API", probe_type: "http", probe_target: "https://example.com/api", probe_service: "example_app", uptime_fraction: 0.85 }
-    ]
+    reads day, uptime(probe_name: "Web", uptime_fraction: 1.0),
+               uptime(probe_name: "API", probe_target: "https://example.com/api", uptime_fraction: 0.85)
 
-    Upright::Rollups::ProbeRollup.stubs(:fetch_uptime_for).with(day).returns(probe_uptimes)
     Upright::Rollups::ProbeRollup.rollup_day(day)
 
     web = Upright::Rollups::ProbeRollup.find_by!(probe_name: "Web", period_start: day.beginning_of_day)
@@ -39,35 +36,65 @@ class Upright::Rollups::ProbeRollupTest < ActiveSupport::TestCase
 
   test "rollup_day keeps probes that share a name but differ by type as distinct rows" do
     day = Date.new(2026, 5, 1)
-    probe_uptimes = [
-      { probe_name: "BC3", probe_type: "traceroute", probe_target: "3.basecamp.com", probe_service: nil, uptime_fraction: 1.0 },
-      { probe_name: "BC3", probe_type: "http", probe_target: "https://app.basecamp.com/up", probe_service: "bc5", uptime_fraction: 0.9 }
-    ]
+    reads day, uptime(probe_name: "BC3", probe_type: "traceroute", probe_target: "3.basecamp.com", probe_service: nil, uptime_fraction: 1.0),
+               uptime(probe_name: "BC3", probe_type: "http", probe_target: "https://app.basecamp.com/up", probe_service: "bc5", uptime_fraction: 0.9)
 
-    Upright::Rollups::ProbeRollup.stubs(:fetch_uptime_for).with(day).returns(probe_uptimes)
     Upright::Rollups::ProbeRollup.rollup_day(day)
 
     rollups = Upright::Rollups::ProbeRollup.where(probe_name: "BC3", period_start: day.beginning_of_day)
     assert_equal 2, rollups.count
-
-    http = rollups.find_by(probe_type: "http")
-    assert_equal "bc5", http.probe_service
-    assert_equal 0.9, http.uptime_fraction
-
-    traceroute = rollups.find_by(probe_type: "traceroute")
-    assert_nil traceroute.probe_service
+    assert_equal 0.9, rollups.find_by(probe_type: "http").uptime_fraction
+    assert_nil rollups.find_by(probe_type: "traceroute").probe_service
   end
 
-  test "rollup_day leaves existing rollups unchanged" do
+  test "rollup_day corrects an existing rollup rather than leaving it wrong forever" do
     existing = upright_rollups_probe_rollups(:example_web_may_11)
+    reads existing.period_start.to_date, uptime(
+      probe_name: existing.probe_name, probe_type: existing.probe_type,
+      probe_target: existing.probe_target, probe_service: existing.probe_service, uptime_fraction: 1.0
+    )
 
-    Upright::Rollups::ProbeRollup.stubs(:fetch_uptime_for).with(existing.period_start.to_date).returns([
-      { probe_name: existing.probe_name, probe_type: existing.probe_type, probe_target: existing.probe_target, probe_service: existing.probe_service, uptime_fraction: 1.0 }
-    ])
     Upright::Rollups::ProbeRollup.rollup_day(existing.period_start.to_date)
 
-    existing.reload
-    assert_equal 0.95, existing.uptime_fraction
-    assert_equal "degraded", existing.status
+    assert_equal 1.0, existing.reload.uptime_fraction
+    assert_equal "operational", existing.status
   end
+
+  test "rollup_day leaves a thinly covered probe unwritten and reports it" do
+    day = Date.new(2026, 5, 1)
+    reads day, uptime(probe_name: "Thin", coverage_fraction: 0.2),
+               uptime(probe_name: "Full", probe_target: "https://example.com/ok", uptime_fraction: 0.9)
+
+    gappy = Upright::Rollups::ProbeRollup.rollup_day(day)
+
+    assert_equal [ "Thin" ], gappy.map(&:probe_name)
+    assert_nil Upright::Rollups::ProbeRollup.find_by(probe_name: "Thin", period_start: day.beginning_of_day)
+    assert Upright::Rollups::ProbeRollup.find_by(probe_name: "Full", period_start: day.beginning_of_day)
+  end
+
+  test "rollup_day won't let a thin recompute overwrite a day it already got right" do
+    existing = upright_rollups_probe_rollups(:example_web_may_11)
+    reads existing.period_start.to_date, uptime(
+      probe_name: existing.probe_name, probe_type: existing.probe_type,
+      probe_target: existing.probe_target, probe_service: existing.probe_service,
+      uptime_fraction: 1.0, coverage_fraction: 0.1
+    )
+
+    Upright::Rollups::ProbeRollup.rollup_day(existing.period_start.to_date)
+
+    assert_equal 0.95, existing.reload.uptime_fraction
+  end
+
+  private
+    def uptime(probe_name:, probe_type: "http", probe_target: "https://example.com", probe_service: "example_app", uptime_fraction: 1.0, coverage_fraction: 1.0)
+      Upright::Rollups::ProbeUptime.new(
+        probe_name: probe_name, probe_type: probe_type, probe_target: probe_target,
+        probe_service: probe_service, uptime_fraction: uptime_fraction, coverage_fraction: coverage_fraction
+      )
+    end
+
+    def reads(day, *probe_uptimes)
+      daily = stub(covered: probe_uptimes.select(&:covered?), gappy: probe_uptimes.reject(&:covered?))
+      Upright::Rollups::DailyUptime.stubs(:new).with(day).returns(daily)
+    end
 end

--- a/test/models/upright/rollups/probe_uptime_test.rb
+++ b/test/models/upright/rollups/probe_uptime_test.rb
@@ -1,0 +1,29 @@
+require "test_helper"
+
+class Upright::Rollups::ProbeUptimeTest < ActiveSupport::TestCase
+  test "counts as covered at or above the configured minimum" do
+    assert probe_uptime(coverage_fraction: 0.9).covered?
+    assert probe_uptime(coverage_fraction: 0.91).covered?
+    assert_not probe_uptime(coverage_fraction: 0.89).covered?
+  end
+
+  test "honours a host's own minimum" do
+    Upright.configuration.rollup_minimum_coverage = 0.5
+
+    assert probe_uptime(coverage_fraction: 0.6).covered?
+  ensure
+    Upright.configuration.rollup_minimum_coverage = nil
+  end
+
+  test "identifies a probe by name, type and target, as the rollups do" do
+    assert_equal [ "Web", "http", "https://example.com" ], probe_uptime.probe_key
+  end
+
+  private
+    def probe_uptime(coverage_fraction: 1.0)
+      Upright::Rollups::ProbeUptime.new(
+        probe_name: "Web", probe_type: "http", probe_target: "https://example.com",
+        probe_service: "example_app", uptime_fraction: 1.0, coverage_fraction: coverage_fraction
+      )
+    end
+end

--- a/test/models/upright/rollups/site_uptime_test.rb
+++ b/test/models/upright/rollups/site_uptime_test.rb
@@ -1,0 +1,104 @@
+require "test_helper"
+
+class Upright::Rollups::SiteUptimeTest < ActiveSupport::TestCase
+  setup { @day = Date.new(2026, 5, 1) }
+
+  test "reads a probe's uptime and how much of the day it covers" do
+    probe_uptime = uptimes_from(site_answering(uptime: 0.82, samples: 2_880)).sole
+
+    assert_equal "Web", probe_uptime.probe_name
+    assert_equal "http", probe_uptime.probe_type
+    assert_equal "https://example.com", probe_uptime.probe_target
+    assert_equal "example_app", probe_uptime.probe_service
+    assert_equal 0.82, probe_uptime.uptime_fraction
+    assert_equal 1.0, probe_uptime.coverage_fraction
+  end
+
+  test "counts coverage against the recording interval" do
+    assert_in_delta 0.5, uptimes_from(site_answering(uptime: 0.9, samples: 1_440)).sole.coverage_fraction
+  end
+
+  test "caps coverage at whole, since a window can hold more samples than expected" do
+    assert_equal 1.0, uptimes_from(site_answering(uptime: 0.9, samples: 5_000)).sole.coverage_fraction
+  end
+
+  test "treats a probe missing from the coverage query as uncovered" do
+    client = mock("prometheus_client")
+    client.stubs(:query).with(has_entries(query: uptime_query)).returns(vector(0.9))
+    client.stubs(:query).with(has_entries(query: coverage_query)).returns({ "result" => [] })
+
+    assert_equal 0.0, uptimes_from(site_with(client)).sole.coverage_fraction
+  end
+
+  test "contributes nothing when the site can't be reached" do
+    client = mock("prometheus_client")
+    client.stubs(:query).raises(Faraday::ConnectionFailed, "down")
+
+    assert_empty uptimes_from(site_with(client))
+  end
+
+  test "counts coverage from the series that stops during a gap, not the daily average that carries on through one" do
+    asked = []
+    client = mock("prometheus_client")
+    client.stubs(:query).with { |options| asked << options[:query]; true }.returns(vector(1.0))
+
+    uptimes_from(site_with(client))
+
+    assert_includes asked, %(upright:probe_uptime_daily{environment="test"})
+    assert_includes asked, %(count_over_time(upright:probe_down_fraction{environment="test"}[1d]))
+  end
+
+  test "asks about a past day at the end of that day" do
+    client = mock("prometheus_client")
+    client.expects(:query).with(has_entries(time: @day.end_of_day.iso8601)).twice.returns(vector(1.0))
+
+    uptimes_from(site_with(client))
+  end
+
+  test "asks about today only up to now" do
+    travel_to Time.zone.local(2026, 5, 12, 9, 30) do
+      client = mock("prometheus_client")
+      client.expects(:query).with(has_entries(time: Time.current.iso8601)).twice.returns(vector(1.0))
+
+      Upright::Rollups::SiteUptime.new(site_with(client), on: Date.current).probe_uptimes
+    end
+  end
+
+  private
+    def uptimes_from(site)
+      Upright::Rollups::SiteUptime.new(site, on: @day).probe_uptimes
+    end
+
+    def site_answering(uptime:, samples:)
+      client = mock("prometheus_client")
+      client.stubs(:query).with(has_entries(query: uptime_query)).returns(vector(uptime))
+      client.stubs(:query).with(has_entries(query: coverage_query)).returns(vector(samples))
+      site_with(client)
+    end
+
+    def site_with(client)
+      Upright::Site.new(code: "sfo", city: "San Francisco", stores_metrics: true).tap do |site|
+        site.stubs(:prometheus_client).returns(client)
+      end
+    end
+
+    def uptime_query
+      %(upright:probe_uptime_daily{environment="test"})
+    end
+
+    def coverage_query
+      %(count_over_time(upright:probe_down_fraction{environment="test"}[1d]))
+    end
+
+    def vector(value)
+      {
+        "resultType" => "vector",
+        "result" => [
+          {
+            "metric" => { "name" => "Web", "type" => "http", "probe_target" => "https://example.com", "probe_service" => "example_app" },
+            "value" => [ 1_777_000_000, value.to_s ]
+          }
+        ]
+      }
+    end
+end


### PR DESCRIPTION
## Problem

The rollup queried only the local Prometheus. `avg_over_time` ignores gaps, so a day holding two hours of samples averaged those two hours. After an outage on the site that runs the rollup, the published uptime was too high. This is the number on the public status page.

## Change

Query every site with `stores_metrics: true`. Each one holds the whole fleet's series, so each can answer for every probe. They differ only in what they were up to receive. Take each probe from the site with the highest coverage for that day.

Coverage is samples found divided by samples expected. Expected comes from `config.rollup_evaluation_interval` (30s, so 2880 per day). Below `config.rollup_minimum_coverage` (0.9) the probe-day is not written, and is counted in a new gauge, `upright_rollup_skipped_probes`.

Rollups are updated in place instead of written once. Backfill is 7 days, was 1. A day skipped for low coverage gets rewritten by a later run once the gap closes. The coverage guard prevents the reverse: a low-coverage recompute cannot overwrite a good row. No schema change is needed, because any stored row already passed the guard.

An unreachable site is logged and contributes nothing. The local Prometheus is queried directly rather than through the proxy, so the rollup does not depend on the local web tier.

## Design

Nine class methods on `ProbeRollup`, including a PromQL builder and a JSON parser, are replaced by three objects:

- `ProbeUptime` — one probe, one day, as one instance saw it. Knows `probe_key` and `covered?`.
- `SiteUptime` — one site's answer for a day. Owns the two queries and the coverage arithmetic.
- `DailyUptime` — the day across sites. Owns the coalescing.

`ProbeRollup` keeps `rollup_day` and `record`.

## Tests

268 tests, 0 failures. Rubocop clean.

New coverage: the highest-coverage site wins; coverage is measured against the interval and capped at 1.0; a probe missing from the coverage query counts as 0; an unreachable site returns nothing; a past day is queried at end of day and today at now; a thin probe is not written; a thin recompute does not overwrite a good row; and the coverage query targets `probe_down_fraction` rather than the daily average, which the other tests would not have caught either way.

## Two things to know

`config.rollup_evaluation_interval` must match the `interval` on the `upright_recording` rule group, which is 30s in ours. If they differ, coverage is measured against the wrong denominator and every day is skipped.

Coverage counts `upright:probe_down_fraction`, so that series has to emit for healthy probes as well as unhealthy ones. The shipped recording rule did not: it was `count(probe_up == 0) / count(probe_up)`, which produces nothing when every region is up. It now falls back to zero. Rules predating that need the same fallback, or `config.rollup_minimum_coverage = 0`.

## Docs

The README's site section had grown four paragraphs across recent changes. The detail now lives in `docs/sites.md` — roles, health metrics, rollups — and the README keeps a summary and a link.


## Tracking

Basecamp: [Rollup reads both Prometheus instances; widen backfill beyond 1 day; coverage-guarded, correctable writes](https://app.basecamp.com/2914079/buckets/43768667/todos/10123843463) — §2 of the [37upright] HA / Failover implementation plan.
