### PR TITLE
Security hardening: proxy SSRF + CSRF, login CSRF, artifact/secret and deploy fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,32 @@
 
 ## Unreleased
 
+### Security
+
+- Fix an authenticated SSRF through the Prometheus/Alertmanager proxies: a
+  protocol-relative path (`//host`) could retarget the upstream request at an
+  arbitrary host (RFC1918, the Docker network, cloud metadata). Forwarded paths
+  are now validated and the resolved host is re-checked, with a `faraday >= 2.14.3`
+  floor (CVE-2026-25765).
+- Refuse cross-site requests to the metrics proxies on the session-cookie path
+  via a Fetch-Metadata / Origin gate; only same-origin, user-initiated, and
+  same-site top-level navigations are honoured (CVE-2026-67990).
+- Require a POST with a valid authenticity token on the `static_credentials`
+  sign-in callback, and fail closed when `ADMIN_PASSWORD` is unset instead of
+  shipping a default password (CVE-2026-67993).
+- Scope the session cookie to the configured hostname rather than its registrable
+  parent, so a sibling domain can't be handed the admin session.
+- Redact `Authorization`/`Cookie` credentials from probe logs, store HTTP probe
+  bodies as inert size-capped artifacts, stop recording Playwright snapshots and
+  logging signed blob URLs, and scope artifact downloads to probe results.
+- Restrict the public status page to incidents affecting a public-facing service,
+  and harden the generated deploy defaults (drop the OTEL Docker-socket mount,
+  bind services to loopback, ship a random proxy token and a CSP template).
+- Update Active Storage to close an arbitrary-file-read → RCE (rails 8.1.3.1,
+  CVE-2026-66066).
+
+### Changed
+
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)
 - Add incidents and scheduled maintenance, with a public timeline and impact banner (#102)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,8 +10,9 @@
   are now validated and the resolved host is re-checked, with a `faraday >= 2.14.3`
   floor (CVE-2026-25765).
 - Refuse cross-site requests to the metrics proxies on the session-cookie path
-  via a Fetch-Metadata / Origin gate; only same-origin, user-initiated, and
-  same-site top-level navigations are honoured (CVE-2026-67990).
+  via a Fetch-Metadata / Origin gate; only same-origin and user-initiated (`none`)
+  requests are honoured, and missing provenance headers fail closed
+  (CVE-2026-67990).
 - Require a POST with a valid authenticity token on the `static_credentials`
   sign-in callback, and fail closed when `ADMIN_PASSWORD` is unset instead of
   shipping a default password (CVE-2026-67993).
@@ -25,6 +26,20 @@
   bind services to loopback, ship a random proxy token and a CSP template).
 - Update Active Storage to close an arbitrary-file-read → RCE (rails 8.1.3.1,
   CVE-2026-66066).
+
+### Upgrading
+
+Some of the security fixes live in generated, host-owned config that a gem
+upgrade does not rewrite. Existing installs should apply these by hand:
+
+- `config/initializers/omniauth.rb`: fail closed when `ADMIN_PASSWORD` is unset
+  instead of `ENV.fetch("ADMIN_PASSWORD", "upright")`, so the well-known default
+  password is removed (compare against the current install template).
+- `config/recurring.yml`: add the `sweep_playwright_videos` entry
+  (`class: "Upright::PlaywrightVideoSweepJob"`) so stranded recordings from a
+  crashed run are still cleaned up.
+- `config/initializers/content_security_policy.rb`: adopt the recommended policy
+  from the install template if you don't already enforce a CSP.
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,8 +19,9 @@
 - Scope the session cookie to the configured hostname rather than its registrable
   parent, so a sibling domain can't be handed the admin session.
 - Redact `Authorization`/`Cookie` credentials from probe logs, store HTTP probe
-  bodies as inert size-capped artifacts, stop recording Playwright snapshots and
-  logging signed blob URLs, and scope artifact downloads to probe results.
+  bodies as inert size-capped artifacts, don't record Playwright traces for
+  authenticated probes (and drop snapshots/signed-blob-URL logging for the rest),
+  and scope artifact downloads to probe results.
 - Restrict the public status page to incidents affecting a public-facing service,
   and harden the generated deploy defaults (drop the OTEL Docker-socket mount,
   bind services to loopback, ship a random proxy token and a CSP template).

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,10 @@
 
 - Fix an authenticated SSRF through the Prometheus/Alertmanager proxies: a
   protocol-relative path (`//host`) could retarget the upstream request at an
-  arbitrary host (RFC1918, the Docker network, cloud metadata). Forwarded paths
-  are now validated and the resolved host is re-checked, with a `faraday >= 2.14.3`
-  floor (CVE-2026-25765).
+  arbitrary host (RFC1918, the Docker network, cloud metadata). The upstream URL
+  is now built structurally — scheme, host and port always come from the
+  configured upstream — and the forwarded path is validated, with a
+  `faraday >= 2.14.3` floor (CVE-2026-25765).
 - Refuse cross-site requests to the metrics proxies on the session-cookie path
   via a Fetch-Metadata / Origin gate; only same-origin and user-initiated (`none`)
   requests are honoured, and missing provenance headers fail closed

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upright (0.4.0)
+    upright (0.3.0)
       cgi
       faraday (>= 2.14.3)
       frozen_record
@@ -822,7 +822,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  upright (0.4.0)
+  upright (0.3.0)
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,8 +1,9 @@
 PATH
   remote: .
   specs:
-    upright (0.3.0)
+    upright (0.4.0)
       cgi
+      faraday (>= 2.14.3)
       frozen_record
       geared_pagination
       importmap-rails
@@ -105,7 +106,7 @@ GEM
       securerandom (>= 0.3)
       tzinfo (~> 2.0, >= 2.0.5)
       uri (>= 0.13.1)
-    addressable (2.8.9)
+    addressable (2.9.0)
       public_suffix (>= 2.0.2, < 8.0)
     aes_key_wrap (1.1.0)
     anyway_config (2.8.0)
@@ -137,7 +138,7 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    faraday (2.14.0)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -646,7 +647,7 @@ CHECKSUMS
   activerecord (8.1.3.1) sha256=0a2fb6c28f4938f6b013a3a549bec0a7e37d535f3dc8990e804bcc3258c0403b
   activestorage (8.1.3.1) sha256=f555254f387b1cffa499d2fd3115d12635eadc5b15206a8534316a67036163ef
   activesupport (8.1.3.1) sha256=85458765f25ea48b9019c46b6bb3fa5683197bf4280d9f06710a6e8d7a831376
-  addressable (2.8.9) sha256=cc154fcbe689711808a43601dee7b980238ce54368d23e127421753e46895485
+  addressable (2.9.0) sha256=7fdf6ac3660f7f4e867a0838be3f6cf722ace541dd97767fa42bc6cfa980c7af
   aes_key_wrap (1.1.0) sha256=b935f4756b37375895db45669e79dfcdc0f7901e12d4e08974d5540c8e0776a5
   anyway_config (2.8.0) sha256=f6797a7231f81202dcd3d0c07284e836e45713e761d320180348b13a5c7c9306
   ast (2.4.3) sha256=954615157c1d6a382bc27d690d973195e79db7f55e9765ac7c481c60bdb4d383
@@ -669,7 +670,7 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
-  faraday (2.14.0) sha256=8699cfe5d97e55268f2596f9a9d5a43736808a943714e3d9a53e6110593941cd
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f
@@ -821,7 +822,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  upright (0.3.0)
+  upright (0.4.0)
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451

--- a/README.md
+++ b/README.md
@@ -77,6 +77,7 @@ Visit http://app.my-upright.localhost:3000 to see your Upright instance.
 The `upright:install` generator creates:
 
 - `config/initializers/upright.rb` - Engine configuration
+- `config/initializers/content_security_policy.rb` - Ready-to-enable CSP covering the engine's CDN dependencies
 - `config/sites.yml` - Site definitions for each VPS you host Upright on
 - `config/prometheus/prometheus.yml` - Prometheus configuration
 - `config/alertmanager/alertmanager.yml` - AlertManager configuration
@@ -146,16 +147,16 @@ production:
     schedule: every minute
 ```
 
-`stores_metrics` marks the sites running a local Prometheus and Alertmanager. Those sites accept metric writes and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others still readable; probe-only sites serve neither. Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token` (`PROMETHEUS_OTLP_TOKEN` by default) instead of an admin session.
+`stores_metrics` marks the sites running a local Prometheus and Alertmanager. Those sites accept metric writes and serve the `/prometheus` and `/alertmanager` proxies, so losing one leaves the others still readable; probe-only sites serve neither. Machine callers — collectors writing metrics, jobs reading a peer — authenticate with `Upright.configuration.proxy_token` instead of an admin session. The install generator writes a random token into `config/initializers/upright.rb`; every site must share the same value, and setting the `PROMETHEUS_OTLP_TOKEN` env var overrides it for rotation.
 
 ### Authentication
 
 #### Static Credentials
 
-Upright uses static credentials by default with username `admin` and password `upright`.
+Upright uses static credentials by default with username `admin` and the password taken from the `ADMIN_PASSWORD` environment variable.
 
-> [!WARNING]
-> Change the default password before deploying to production by setting the `ADMIN_PASSWORD` environment variable.
+> [!IMPORTANT]
+> There is no default password: `ADMIN_PASSWORD` must be set, and sign-in fails closed without it. Set it as a Kamal secret in production (the generated `config/deploy.yml` already lists it) and export it locally for development.
 
 
 #### OpenID Connect
@@ -213,8 +214,14 @@ class PingProbe < FrozenRecord::Base
 
   stagger_by_site 3.seconds
 
+  # Hostnames, IPv4, and IPv6 addresses only. The first character may not be
+  # a dash, so a configured host can never be mistaken for a ping flag.
+  HOST_PATTERN = /\A[a-z0-9:][a-z0-9:._-]*\z/i
+
   def check
-    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", host)
+    raise ArgumentError, "invalid ping host: #{host.inspect}" unless HOST_PATTERN.match?(host.to_s)
+
+    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", "--", host)
     status.success?
   end
 
@@ -441,6 +448,7 @@ proxy:
 env:
   secret:
     - RAILS_MASTER_KEY
+    - ADMIN_PASSWORD
   tags:
     amsterdam:
       SITE_SUBDOMAIN: ams
@@ -552,7 +560,7 @@ bin/dev
 
 Visit http://app.upright.localhost:3000 and sign in with:
 - **Username**: `admin`
-- **Password**: `upright` (or value of `ADMIN_PASSWORD` env var)
+- **Password**: the value of the `ADMIN_PASSWORD` env var, e.g. `ADMIN_PASSWORD=upright bin/dev` (a throwaway value like this is fine for local testing only — never for a deployed site)
 
 ### Testing Playwright Probes
 

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -1,6 +1,15 @@
 module Upright::ProxyAuthentication
   extend ActiveSupport::Concern
 
+  included do
+    # Rails' token CSRF is skipped on the proxies because the embedded
+    # Prometheus/Alertmanager UIs issue same-origin requests that can't carry a
+    # Rails authenticity token. Guard the session-cookie path instead with a
+    # Fetch-Metadata / Origin check so a cross-site request can't ride the
+    # victim's Lax session cookie into upstream write APIs (CVE-2026-67990).
+    prepend_before_action :block_cross_site_session_requests
+  end
+
   private
     def authenticate_user
       if request.authorization.present?
@@ -13,6 +22,23 @@ module Upright::ProxyAuthentication
     def authenticate_proxy_token
       authenticate_or_request_with_http_token do |token|
         ActiveSupport::SecurityUtils.secure_compare(token, Upright.configuration.proxy_token.to_s)
+      end
+    end
+
+    # Automation authenticates with a bearer token and is exempt; only the
+    # browser session-cookie path is forgeable, and a genuine same-origin call
+    # from the embedded UI is never cross-site.
+    def block_cross_site_session_requests
+      head :forbidden if request.authorization.blank? && cross_site_request?
+    end
+
+    def cross_site_request?
+      if (site = request.headers["Sec-Fetch-Site"]).present?
+        !site.in?(%w[ same-origin same-site none ])
+      elsif (origin = request.headers["Origin"]).present?
+        origin != request.base_url
+      else
+        false
       end
     end
 end

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -5,7 +5,7 @@ module Upright::ProxyAuthentication
   # nothing outside the RFC 3986 path character set. This is what stops a request
   # like `/prometheus//169.254.169.254/…` from retargeting Faraday at another host
   # (SSRF, CVE-2026-25765).
-  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~%!$&'()*+,;=:@/]*\z}
+  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~!$&'()*+,;=:@/]*\z}
   MAX_UPSTREAM_QUERY = 4096
 
   # Destructive/admin upstream endpoints automation must never reach with a token
@@ -56,9 +56,11 @@ module Upright::ProxyAuthentication
       elsif origin.present?
         origin != request.base_url
       else
-        # No Fetch-Metadata and no Origin (a pre-Fetch-Metadata browser): fail
-        # closed on state-changing methods, allow plain reads.
-        !request.get? && !request.head?
+        # No Fetch-Metadata and no Origin: treat as cross-site and refuse. Every
+        # current browser sends Sec-Fetch-Site (and the embedded same-origin UI
+        # does too), so only a pre-2023 client omits it; failing closed keeps a
+        # header-less cross-site GET from riding the Lax session cookie.
+        true
       end
     end
 
@@ -69,7 +71,12 @@ module Upright::ProxyAuthentication
       path, separator, query = raw.to_s.partition("?")
       path = "/" if path.empty?
 
-      if path.start_with?("//") || path.include?("..") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+      # Reject an authority override (//host), traversal, characters outside the
+      # path set, and ANY percent-encoding in the path. The proxied UIs only
+      # percent-encode query strings; allowing it in the path would let a
+      # double-encoded separator (%252f → %2f → /) decode on the upstream and slip
+      # an authority override or a denied `/-/` prefix past these checks.
+      if path.start_with?("//") || path.include?("..") || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
         nil
       else
         "#{path}#{separator}#{query}"

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -1,12 +1,19 @@
 module Upright::ProxyAuthentication
   extend ActiveSupport::Concern
 
+  # A forwarded path may only be a path: no authority (`//host`), no traversal,
+  # nothing outside the RFC 3986 path character set. This is what stops a request
+  # like `/prometheus//169.254.169.254/…` from retargeting Faraday at another host
+  # (SSRF, CVE-2026-25765).
+  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~%!$&'()*+,;=:@/]*\z}
+  MAX_UPSTREAM_QUERY = 4096
+
+  # Destructive/admin upstream endpoints automation must never reach with a token
+  # (Prometheus `/-/reload`, `/-/quit`, Alertmanager admin under `/-/`). The
+  # embedded same-origin UI can still use them on the session path.
+  TOKEN_DENIED_PREFIXES = %w[ /-/ ].freeze
+
   included do
-    # Rails' token CSRF is skipped on the proxies because the embedded
-    # Prometheus/Alertmanager UIs issue same-origin requests that can't carry a
-    # Rails authenticity token. Guard the session-cookie path instead with a
-    # Fetch-Metadata / Origin check so a cross-site request can't ride the
-    # victim's Lax session cookie into upstream write APIs (CVE-2026-67990).
     prepend_before_action :block_cross_site_session_requests
   end
 
@@ -25,20 +32,66 @@ module Upright::ProxyAuthentication
       end
     end
 
-    # Automation authenticates with a bearer token and is exempt; only the
-    # browser session-cookie path is forgeable, and a genuine same-origin call
-    # from the embedded UI is never cross-site.
+    # CSRF gate for the browser (session-cookie) path. Rails token CSRF is skipped
+    # on the proxies because the embedded Prometheus/Alertmanager UIs make
+    # same-origin requests that can't carry an authenticity token, so we gate with
+    # Fetch-Metadata / Origin instead (CVE-2026-67990). Automation authenticates
+    # with a bearer token and is out of scope here; a missing/invalid token is not
+    # exempt — it simply falls through to a 401 at authentication.
     def block_cross_site_session_requests
       head :forbidden if request.authorization.blank? && cross_site_request?
     end
 
     def cross_site_request?
-      if (site = request.headers["Sec-Fetch-Site"]).present?
-        !site.in?(%w[ same-origin same-site none ])
-      elsif (origin = request.headers["Origin"]).present?
+      site = request.headers["Sec-Fetch-Site"]
+      origin = request.headers["Origin"]
+
+      if site.present?
+        # Same-origin (the embedded UI) and user-initiated `none` (typed URL /
+        # bookmark) are fine; a same-site *top-level GET navigation* is an admin
+        # moving between our own subdomains. Everything else — cross-site, and any
+        # same-site sub-resource or write — is refused.
+        !(site.in?(%w[ same-origin none ]) ||
+          (site == "same-site" && request.get? && request.headers["Sec-Fetch-Mode"] == "navigate"))
+      elsif origin.present?
         origin != request.base_url
       else
-        false
+        # No Fetch-Metadata and no Origin (a pre-Fetch-Metadata browser): fail
+        # closed on state-changing methods, allow plain reads.
+        !request.get? && !request.head?
       end
+    end
+
+    # Validate the operator-controlled proxy path before it reaches Faraday, and
+    # cap the query so an operator query can't be turned into a nested-params DoS.
+    # Returns the safe "path[?query]" to forward, or nil to reject.
+    def sanitized_upstream_path(raw)
+      path, separator, query = raw.to_s.partition("?")
+      path = "/" if path.empty?
+
+      if path.start_with?("//") || path.include?("..") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+        nil
+      else
+        "#{path}#{separator}#{query}"
+      end
+    end
+
+    # Belt-and-suspenders after path validation: resolve the forwarded path the
+    # same way Faraday's Connection does (URI#merge) and require that it still
+    # lands on the configured upstream host and port. This catches an authority
+    # override (`//host`) even if the character-level check above ever misses one.
+    def upstream_host_ok?(base_url, forward)
+      base = URI.parse(base_url)
+      built = base.merge(forward)
+      built.host == base.host && built.port == base.port
+    rescue URI::Error
+      false
+    end
+
+    # A token may read through the proxy but not drive destructive or
+    # state-changing upstream endpoints; those stay on the same-origin session UI.
+    def token_forbidden_path?(path)
+      request.authorization.present? &&
+        ((!request.get? && !request.head?) || path.start_with?(*TOKEN_DENIED_PREFIXES))
     end
 end

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -20,11 +20,6 @@ module Upright::ProxyAuthentication
   TOKEN_DENIED_PREFIXES = %w[ /-/ ]
 
   included do
-    # The embedded Prometheus/Alertmanager UIs make same-origin requests that
-    # can't carry an authenticity token, so the proxies trade Rails token CSRF
-    # for the Fetch-Metadata gate below. Both halves live here so a new proxy
-    # controller can't pick up one without the other.
-    skip_forgery_protection
     prepend_before_action :block_cross_site_session_requests
   end
 
@@ -50,10 +45,24 @@ module Upright::ProxyAuthentication
       end
     end
 
+    # The proxies can't demand an authenticity token: the embedded Prometheus and
+    # Alertmanager UIs post from JS we don't render, so there's no token to embed.
+    # Rather than skipping Rails' verification, widen what counts as verified — a
+    # valid token, a bearer token (not an ambient credential, so a cross-site page
+    # can't attach one), or same-origin provenance. Cross-site requests are
+    # already refused by #block_cross_site_session_requests; leaving verification
+    # in the chain means removing that gate can't quietly leave the proxies with
+    # no CSRF defence at all.
+    def verified_request?
+      super || proxy_token_provided? || !cross_site_request?
+    end
+
     # CSRF gate for the browser (session-cookie) path: nothing in Action Pack
-    # reads Fetch-Metadata, so we gate on it here (CVE-2026-67990). Automation
-    # authenticates with a bearer token and is out of scope; a missing/invalid
-    # token is not exempt — it simply falls through to a 401 at authentication.
+    # reads Fetch-Metadata, so we gate on it here (CVE-2026-67990). Unlike Rails'
+    # token verification this covers GET too, because a proxied GET can reach a
+    # state-changing upstream endpoint. Automation authenticates with a bearer
+    # token and is out of scope; a missing/invalid token is not exempt — it simply
+    # falls through to a 401 at authentication.
     def block_cross_site_session_requests
       head :forbidden if !proxy_token_provided? && cross_site_request?
     end

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -47,12 +47,12 @@ module Upright::ProxyAuthentication
       origin = request.headers["Origin"]
 
       if site.present?
-        # Same-origin (the embedded UI) and user-initiated `none` (typed URL /
-        # bookmark) are fine; a same-site *top-level GET navigation* is an admin
-        # moving between our own subdomains. Everything else — cross-site, and any
-        # same-site sub-resource or write — is refused.
-        !(site.in?(%w[ same-origin none ]) ||
-          (site == "same-site" && request.get? && request.headers["Sec-Fetch-Mode"] == "navigate"))
+        # Only same-origin (the embedded UI) and user-initiated `none` (a typed
+        # URL or bookmark) are allowed. same-site is refused too: a sibling on the
+        # same registrable domain (evil.example.com vs ams.upright.example.com) is
+        # same-site, and a top-level navigation from it would otherwise carry the
+        # Lax cookie into a forged proxy request.
+        !site.in?(%w[ same-origin none ])
       elsif origin.present?
         origin != request.base_url
       else
@@ -71,12 +71,13 @@ module Upright::ProxyAuthentication
       path, separator, query = raw.to_s.partition("?")
       path = "/" if path.empty?
 
-      # Reject an authority override (//host), traversal, characters outside the
-      # path set, and ANY percent-encoding in the path. The proxied UIs only
-      # percent-encode query strings; allowing it in the path would let a
-      # double-encoded separator (%252f → %2f → /) decode on the upstream and slip
-      # an authority override or a denied `/-/` prefix past these checks.
-      if path.start_with?("//") || path.include?("..") || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+      # Reject an authority override (//host), any dot-segment (`.`/`..`),
+      # characters outside the path set, and ANY percent-encoding in the path.
+      # Faraday resolves the path with URI#merge, which collapses `.`/`..` and
+      # decodes escapes, so `/./-/reload` or a double-encoded `/%252d%252freload`
+      # would otherwise slip an authority override or a denied `/-/` prefix past
+      # these checks and be normalized on the upstream.
+      if path.start_with?("//") || path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
         nil
       else
         "#{path}#{separator}#{query}"

--- a/app/controllers/concerns/upright/proxy_authentication.rb
+++ b/app/controllers/concerns/upright/proxy_authentication.rb
@@ -2,28 +2,46 @@ module Upright::ProxyAuthentication
   extend ActiveSupport::Concern
 
   # A forwarded path may only be a path: no authority (`//host`), no traversal,
-  # nothing outside the RFC 3986 path character set. This is what stops a request
-  # like `/prometheus//169.254.169.254/…` from retargeting Faraday at another host
-  # (SSRF, CVE-2026-25765).
+  # nothing outside the RFC 3986 path character set. The upstream host and port
+  # never come from the request (see #upstream_url), so this isn't the SSRF
+  # control — it keeps a normalizing hop from rewriting the path into a denied
+  # one, and keeps junk out of the upstream request.
   SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~!$&'()*+,;=:@/]*\z}
+
+  # Cap the query we relay upstream. Rack's query parser already protects *us*
+  # from a nested-params bomb (it enforces param count, depth and bytesize limits
+  # before the action runs); this is about not handing an unbounded query to
+  # Prometheus or Alertmanager.
   MAX_UPSTREAM_QUERY = 4096
 
   # Destructive/admin upstream endpoints automation must never reach with a token
   # (Prometheus `/-/reload`, `/-/quit`, Alertmanager admin under `/-/`). The
   # embedded same-origin UI can still use them on the session path.
-  TOKEN_DENIED_PREFIXES = %w[ /-/ ].freeze
+  TOKEN_DENIED_PREFIXES = %w[ /-/ ]
 
   included do
+    # The embedded Prometheus/Alertmanager UIs make same-origin requests that
+    # can't carry an authenticity token, so the proxies trade Rails token CSRF
+    # for the Fetch-Metadata gate below. Both halves live here so a new proxy
+    # controller can't pick up one without the other.
+    skip_forgery_protection
     prepend_before_action :block_cross_site_session_requests
   end
 
   private
     def authenticate_user
-      if request.authorization.present?
+      if proxy_token_provided?
         authenticate_proxy_token
       else
         super
       end
+    end
+
+    # Specifically "carries a bearer token", not "carries any Authorization
+    # header": a `Basic` header belongs on the session path, and shouldn't buy an
+    # exemption from the cross-site gate on its way to a 401.
+    def proxy_token_provided?
+      ActionController::HttpAuthentication::Token.token_and_options(request).present?
     end
 
     def authenticate_proxy_token
@@ -32,19 +50,16 @@ module Upright::ProxyAuthentication
       end
     end
 
-    # CSRF gate for the browser (session-cookie) path. Rails token CSRF is skipped
-    # on the proxies because the embedded Prometheus/Alertmanager UIs make
-    # same-origin requests that can't carry an authenticity token, so we gate with
-    # Fetch-Metadata / Origin instead (CVE-2026-67990). Automation authenticates
-    # with a bearer token and is out of scope here; a missing/invalid token is not
-    # exempt — it simply falls through to a 401 at authentication.
+    # CSRF gate for the browser (session-cookie) path: nothing in Action Pack
+    # reads Fetch-Metadata, so we gate on it here (CVE-2026-67990). Automation
+    # authenticates with a bearer token and is out of scope; a missing/invalid
+    # token is not exempt — it simply falls through to a 401 at authentication.
     def block_cross_site_session_requests
-      head :forbidden if request.authorization.blank? && cross_site_request?
+      head :forbidden if !proxy_token_provided? && cross_site_request?
     end
 
     def cross_site_request?
       site = request.headers["Sec-Fetch-Site"]
-      origin = request.headers["Origin"]
 
       if site.present?
         # Only same-origin (the embedded UI) and user-initiated `none` (a typed
@@ -53,8 +68,11 @@ module Upright::ProxyAuthentication
         # same-site, and a top-level navigation from it would otherwise carry the
         # Lax cookie into a forged proxy request.
         !site.in?(%w[ same-origin none ])
-      elsif origin.present?
-        origin != request.base_url
+      elsif request.origin.present?
+        # The same comparison Rails makes in #valid_request_origin?. A sandboxed
+        # iframe or a cross-origin redirect sends `Origin: null`, which never
+        # equals base_url and so lands here as cross-site.
+        request.origin != request.base_url
       else
         # No Fetch-Metadata and no Origin: treat as cross-site and refuse. Every
         # current browser sends Sec-Fetch-Site (and the embedded same-origin UI
@@ -64,42 +82,44 @@ module Upright::ProxyAuthentication
       end
     end
 
-    # Validate the operator-controlled proxy path before it reaches Faraday, and
-    # cap the query so an operator query can't be turned into a nested-params DoS.
-    # Returns the safe "path[?query]" to forward, or nil to reject.
-    def sanitized_upstream_path(raw)
-      path, separator, query = raw.to_s.partition("?")
+    # Build the upstream URL for a forwarded request. Scheme, host and port always
+    # come from the configured upstream, so no forwarded path can retarget Faraday
+    # at another host — an authority override like
+    # `/prometheus//169.254.169.254/latest/meta-data` (SSRF, CVE-2026-25765) can't
+    # survive being assigned as a path component. Returns the URI to forward, or
+    # nil to reject.
+    def upstream_url(base_url, raw)
+      path, _separator, query = raw.to_s.partition("?")
       path = "/" if path.empty?
 
-      # Reject an authority override (//host), any dot-segment (`.`/`..`),
-      # characters outside the path set, and ANY percent-encoding in the path.
-      # Faraday resolves the path with URI#merge, which collapses `.`/`..` and
-      # decodes escapes, so `/./-/reload` or a double-encoded `/%252d%252freload`
-      # would otherwise slip an authority override or a denied `/-/` prefix past
-      # these checks and be normalized on the upstream.
-      if path.start_with?("//") || path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
-        nil
-      else
-        "#{path}#{separator}#{query}"
+      if safe_upstream_path?(path) && query.length <= MAX_UPSTREAM_QUERY
+        URI.parse(base_url).tap do |url|
+          url.path = path
+          url.query = query.presence
+        end
       end
+    rescue URI::Error
+      nil
     end
 
-    # Belt-and-suspenders after path validation: resolve the forwarded path the
-    # same way Faraday's Connection does (URI#merge) and require that it still
-    # lands on the configured upstream host and port. This catches an authority
-    # override (`//host`) even if the character-level check above ever misses one.
-    def upstream_host_ok?(base_url, forward)
-      base = URI.parse(base_url)
-      built = base.merge(forward)
-      built.host == base.host && built.port == base.port
-    rescue URI::Error
-      false
+    # Faraday and the upstream both normalize and percent-decode the path, so
+    # `/./-/reload` or a double-encoded `/%252d%252freload` would arrive at a
+    # denied `/-/` endpoint if we only checked the literal prefix. Reject any
+    # dot-segment, any percent-encoding, and anything outside the path set.
+    # Rack::Utils.valid_path? runs first: it screens null bytes and broken
+    # encoding, which would otherwise raise out of the regexp match.
+    def safe_upstream_path?(path)
+      Rack::Utils.valid_path?(path) &&
+        !path.start_with?("//") &&
+        !path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) &&
+        !path.include?("%") &&
+        path.match?(SAFE_UPSTREAM_PATH)
     end
 
     # A token may read through the proxy but not drive destructive or
     # state-changing upstream endpoints; those stay on the same-origin session UI.
     def token_forbidden_path?(path)
-      request.authorization.present? &&
+      proxy_token_provided? &&
         ((!request.get? && !request.head?) || path.start_with?(*TOKEN_DENIED_PREFIXES))
     end
 end

--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -1,27 +1,24 @@
 class Upright::AlertmanagerProxyController < Upright::ApplicationController
   include Upright::ProxyAuthentication
 
-  skip_forgery_protection
-
   def show
   end
 
   def proxy
-    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/alertmanager"))
-    path = forward&.split("?", 2)&.first
+    url = upstream_url(alertmanager_url, request.fullpath.delete_prefix("/alertmanager"))
 
-    if forward.nil? || !upstream_host_ok?(alertmanager_url, forward)
+    if url.nil?
       head :bad_request
-    elsif token_forbidden_path?(path)
+    elsif token_forbidden_path?(url.path)
       head :forbidden
     else
-      proxy_to_alertmanager forward, body: request.body&.read
+      proxy_to_alertmanager url, body: request.body&.read
     end
   end
 
   private
-    def proxy_to_alertmanager(path, method: request.method, body: nil)
-      response = Faraday.new(url: alertmanager_url).run_request(method.downcase.to_sym, path, body, { "Content-Type" => request.content_type })
+    def proxy_to_alertmanager(url, method: request.method, body: nil)
+      response = Faraday.new(url: alertmanager_url).run_request(method.downcase.to_sym, url.to_s, body, { "Content-Type" => request.content_type })
 
       render body: response.body, status: response.status, content_type: response.headers["content-type"]
     end

--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -7,7 +7,16 @@ class Upright::AlertmanagerProxyController < Upright::ApplicationController
   end
 
   def proxy
-    proxy_to_alertmanager request.fullpath.delete_prefix("/alertmanager"), body: request.body&.read
+    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/alertmanager"))
+    path = forward&.split("?", 2)&.first
+
+    if forward.nil? || !upstream_host_ok?(alertmanager_url, forward)
+      head :bad_request
+    elsif token_forbidden_path?(path)
+      head :forbidden
+    else
+      proxy_to_alertmanager forward, body: request.body&.read
+    end
   end
 
   private

--- a/app/controllers/upright/artifacts_controller.rb
+++ b/app/controllers/upright/artifacts_controller.rb
@@ -1,5 +1,5 @@
 class Upright::ArtifactsController < Upright::ApplicationController
   def show
-    @artifact = ActiveStorage::Attachment.find(params[:id])
+    @artifact = ActiveStorage::Attachment.where(record_type: "Upright::ProbeResult").find(params[:id])
   end
 end

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -4,6 +4,7 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   skip_forgery_protection
 
   skip_before_action :authenticate_user, only: :otlp
+  skip_before_action :block_cross_site_session_requests, only: :otlp
   before_action :authenticate_proxy_token, only: :otlp
 
   UNSUPPORTED_PATHS = %w[/api/v1/notifications]
@@ -12,12 +13,17 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   end
 
   def proxy
-    path = request.fullpath.sub(%r{^/prometheus}, "")
+    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/prometheus"))
+    path = forward&.split("?", 2)&.first
 
-    if path.start_with?(*UNSUPPORTED_PATHS)
+    if forward.nil? || !upstream_host_ok?(Upright.configuration.prometheus_url, forward)
+      head :bad_request
+    elsif path.start_with?(*UNSUPPORTED_PATHS)
       head :not_found
+    elsif token_forbidden_path?(path)
+      head :forbidden
     else
-      proxy_to_prometheus(path)
+      proxy_to_prometheus(forward)
     end
   end
 

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -1,8 +1,6 @@
 class Upright::PrometheusProxyController < Upright::ApplicationController
   include Upright::ProxyAuthentication
 
-  skip_forgery_protection
-
   skip_before_action :authenticate_user, only: :otlp
   skip_before_action :block_cross_site_session_requests, only: :otlp
   before_action :authenticate_proxy_token, only: :otlp
@@ -13,17 +11,16 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   end
 
   def proxy
-    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/prometheus"))
-    path = forward&.split("?", 2)&.first
+    url = upstream_url(Upright.configuration.prometheus_url, request.fullpath.delete_prefix("/prometheus"))
 
-    if forward.nil? || !upstream_host_ok?(Upright.configuration.prometheus_url, forward)
+    if url.nil?
       head :bad_request
-    elsif path.start_with?(*UNSUPPORTED_PATHS)
+    elsif url.path.start_with?(*UNSUPPORTED_PATHS)
       head :not_found
-    elsif token_forbidden_path?(path)
+    elsif token_forbidden_path?(url.path)
       head :forbidden
     else
-      proxy_to_prometheus(forward)
+      proxy_to_prometheus(url)
     end
   end
 
@@ -37,10 +34,10 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   end
 
   private
-    def proxy_to_prometheus(path, method: request.method, body: nil)
+    def proxy_to_prometheus(url, method: request.method, body: nil)
       response = prometheus_connection.run_request(
         method.downcase.to_sym,
-        path,
+        url.to_s,
         body,
         { "Content-Type" => request.content_type }
       )

--- a/app/controllers/upright/public/base_controller.rb
+++ b/app/controllers/upright/public/base_controller.rb
@@ -1,3 +1,7 @@
+# TODO: Throttle the public status routes (e.g. with Rack::Attack) if the 15s
+# Prometheus result cache (Upright::Services::LiveStatus::CACHE_TTL) proves
+# insufficient against anonymous request bursts. rack-attack isn't a dependency
+# yet, so we lean on caching for now.
 class Upright::Public::BaseController < ActionController::Base
   layout "upright/public"
 

--- a/app/controllers/upright/public/incidents_controller.rb
+++ b/app/controllers/upright/public/incidents_controller.rb
@@ -1,6 +1,6 @@
 class Upright::Public::IncidentsController < Upright::Public::BaseController
   def show
-    @incident = Upright::Incident.find(params[:id])
+    @incident = Upright::Incident.public_facing.find(params[:id])
     expires_in 15.seconds, public: true
   end
 end

--- a/app/controllers/upright/public/services_controller.rb
+++ b/app/controllers/upright/public/services_controller.rb
@@ -1,9 +1,10 @@
 class Upright::Public::ServicesController < Upright::Public::BaseController
   def index
     @services = Upright::Service.public_facing
-    @active_incidents = Upright::Incident.reactive.active.order(starts_at: :desc)
-    @active_maintenances = Upright::Maintenance.active.order(:starts_at)
-    @upcoming_maintenances = Upright::Maintenance.upcoming.order(:starts_at)
+    @overall_status = @services.overall_status(incidents: Upright::Incident.public_facing)
+    @active_incidents = Upright::Incident.public_facing.reactive.active.order(starts_at: :desc)
+    @active_maintenances = Upright::Maintenance.public_facing.active.order(:starts_at)
+    @upcoming_maintenances = Upright::Maintenance.public_facing.upcoming.order(:starts_at)
     expires_in 15.seconds, public: true
   end
 end

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -1,8 +1,8 @@
 class Upright::SessionsController < Upright::ApplicationController
   skip_before_action :authenticate_user, only: [ :new, :create ]
-  skip_forgery_protection only: :create
 
   before_action :ensure_not_signed_in, only: [ :new, :create ]
+  before_action :require_post_for_credential_callback, only: :create
 
   def new
   end
@@ -23,6 +23,18 @@ class Upright::SessionsController < Upright::ApplicationController
   private
     def ensure_not_signed_in
       redirect_to upright.site_root_path if session[:user_info].present?
+    end
+
+    # The credential (static_credentials) callback must arrive as a POST so it
+    # passes through Rails' authenticity-token check: a cross-site top-level GET
+    # carries the Lax session cookie and could otherwise plant an attacker-chosen
+    # session (CVE-2026-67993). External identity providers (e.g. OpenID Connect)
+    # legitimately redirect back via GET and are validated by OmniAuth's own
+    # state nonce before we reach here, so they are exempt.
+    def require_post_for_credential_callback
+      if request.get? && params[:provider].to_s == "static_credentials"
+        head :not_found
+      end
     end
 
     def upright

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -1,8 +1,14 @@
 class Upright::SessionsController < Upright::ApplicationController
   skip_before_action :authenticate_user, only: [ :new, :create ]
+  # External identity providers (OpenID Connect, including
+  # `response_mode=form_post`) return to the callback without a Rails authenticity
+  # token and are validated by the provider's own state nonce, so Rails' automatic
+  # token check is skipped here. The static_credentials callback is same-origin and
+  # MUST present a token — enforced explicitly in verify_credential_callback.
+  skip_forgery_protection only: :create
 
   before_action :ensure_not_signed_in, only: [ :new, :create ]
-  before_action :require_post_for_credential_callback, only: :create
+  before_action :verify_credential_callback, only: :create
 
   def new
   end
@@ -25,15 +31,18 @@ class Upright::SessionsController < Upright::ApplicationController
       redirect_to upright.site_root_path if session[:user_info].present?
     end
 
-    # The credential (static_credentials) callback must arrive as a POST so it
-    # passes through Rails' authenticity-token check: any other verb (a Lax-cookie
-    # GET, or a HEAD that CSRF also skips) could otherwise plant an attacker-chosen
-    # session (CVE-2026-67993). External identity providers (e.g. OpenID Connect)
-    # legitimately redirect back via GET and are validated by OmniAuth's own state
-    # nonce before we reach here, so they are exempt.
-    def require_post_for_credential_callback
-      if !request.post? && params[:provider].to_s == "static_credentials"
+    # The static_credentials callback must arrive as a POST carrying a valid
+    # authenticity token: any other verb (a Lax-cookie GET, or a HEAD that CSRF
+    # skips) or a missing/foreign token could otherwise plant an attacker-chosen
+    # session (CVE-2026-67993). External providers are validated by their own
+    # state nonce (see skip_forgery_protection above) and are exempt.
+    def verify_credential_callback
+      return unless params[:provider].to_s == "static_credentials"
+
+      if !request.post?
         head :not_found
+      elsif !verified_request?
+        raise ActionController::InvalidAuthenticityToken
       end
     end
 

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -8,7 +8,7 @@ class Upright::SessionsController < Upright::ApplicationController
   end
 
   def create
-    return_to = session[:return_to]
+    return_to = safe_return_to(session[:return_to])
     reset_session
     user = Upright::User.from_omniauth(request.env["omniauth.auth"])
     session[:user_info] = { email: user.email, name: user.name }
@@ -26,15 +26,28 @@ class Upright::SessionsController < Upright::ApplicationController
     end
 
     # The credential (static_credentials) callback must arrive as a POST so it
-    # passes through Rails' authenticity-token check: a cross-site top-level GET
-    # carries the Lax session cookie and could otherwise plant an attacker-chosen
+    # passes through Rails' authenticity-token check: any other verb (a Lax-cookie
+    # GET, or a HEAD that CSRF also skips) could otherwise plant an attacker-chosen
     # session (CVE-2026-67993). External identity providers (e.g. OpenID Connect)
-    # legitimately redirect back via GET and are validated by OmniAuth's own
-    # state nonce before we reach here, so they are exempt.
+    # legitimately redirect back via GET and are validated by OmniAuth's own state
+    # nonce before we reach here, so they are exempt.
     def require_post_for_credential_callback
-      if request.get? && params[:provider].to_s == "static_credentials"
+      if !request.post? && params[:provider].to_s == "static_credentials"
         head :not_found
       end
+    end
+
+    # `allow_other_host: true` is needed to return across our own subdomains
+    # (app → a site), so bound it: only honour a stored return_to whose host is
+    # this deployment's hostname or a subdomain of it, never a foreign host (F-15).
+    def safe_return_to(url)
+      return nil if url.blank?
+
+      host = URI.parse(url).host
+      hostname = Upright.configuration.hostname
+      url if host && hostname.present? && (host == hostname || host.end_with?(".#{hostname}"))
+    rescue URI::InvalidURIError
+      nil
     end
 
     def upright

--- a/app/javascript/upright/controllers/sites_map_controller.js
+++ b/app/javascript/upright/controllers/sites_map_controller.js
@@ -14,11 +14,21 @@ export default class extends Controller {
 
       L.marker([site.lat, site.lon])
         .addTo(map)
-        .bindPopup(`<strong>${site.hostname}</strong><br>${site.city}`)
+        .bindPopup(this.popupContent(site))
         .on("mouseover", function() { this.openPopup() })
         .on("mouseout", function() { this.closePopup() })
         .on("click", () => window.location.href = site.url)
     }
+  }
+
+  // Build the popup as DOM nodes so hostname and city render as text,
+  // never as HTML.
+  popupContent(site) {
+    const content = document.createElement("div")
+    const hostname = document.createElement("strong")
+    hostname.textContent = site.hostname
+    content.append(hostname, document.createElement("br"), site.city ?? "")
+    return content
   }
 
   get tileUrl() {

--- a/app/jobs/upright/playwright_video_sweep_job.rb
+++ b/app/jobs/upright/playwright_video_sweep_job.rb
@@ -1,0 +1,21 @@
+# Playwright source recordings are deleted right after they're saved as
+# artifacts, but a crashed run can still strand them. Sweep any video files
+# old enough that no probe run could still be using them.
+class Upright::PlaywrightVideoSweepJob < Upright::ApplicationJob
+  queue_as :default
+
+  MAX_AGE = 1.hour
+
+  def perform
+    stray_videos.each do |path|
+      File.delete(path) if File.mtime(path) < MAX_AGE.ago
+    rescue Errno::ENOENT
+      # Already gone
+    end
+  end
+
+  private
+    def stray_videos
+      Dir.glob(Upright.configuration.video_storage_dir.join("*.webm").to_s)
+    end
+end

--- a/app/models/concerns/upright/incidents/lifecycle.rb
+++ b/app/models/concerns/upright/incidents/lifecycle.rb
@@ -10,6 +10,7 @@ module Upright::Incidents::Lifecycle
     scope :past,     -> { resolved.order(starts_at: :desc) }
 
     scope :reactive, -> { where.not(type: "Upright::Maintenance").or(where(type: nil)) }
+    scope :planned,  -> { where(type: "Upright::Maintenance") }
 
     scope :for_service, ->(code) {
       joins(:affected_services).where(upright_incident_affected_services: { service_code: code })

--- a/app/models/concerns/upright/playwright/trace_recording.rb
+++ b/app/models/concerns/upright/playwright/trace_recording.rb
@@ -14,7 +14,10 @@ module Upright::Playwright::TraceRecording
     end
 
     def start_trace
-      context.tracing.start(screenshots: true, snapshots: true)
+      # snapshots capture full DOM and network payloads, including Cookie and
+      # Authorization headers, turning traces into credential stores. Keep
+      # screenshots only.
+      context.tracing.start(screenshots: true, snapshots: false)
     end
 
     def stop_trace

--- a/app/models/concerns/upright/playwright/trace_recording.rb
+++ b/app/models/concerns/upright/playwright/trace_recording.rb
@@ -14,13 +14,19 @@ module Upright::Playwright::TraceRecording
     end
 
     def start_trace
-      # snapshots capture full DOM and network payloads, including Cookie and
-      # Authorization headers, turning traces into credential stores. Keep
-      # screenshots only.
+      # Authenticated probes are not traced at all: a trace records network
+      # activity, which for an authenticated context includes Cookie and
+      # Authorization headers. Unauthenticated probes carry no credentials, so
+      # they still get a screenshots-only trace with snapshots (DOM + network
+      # payloads) disabled.
+      return if authentication_service.present?
+
       context.tracing.start(screenshots: true, snapshots: false)
     end
 
     def stop_trace
+      return if authentication_service.present?
+
       trace_path = trace_dir.join("#{SecureRandom.hex}.zip").to_s
       FileUtils.mkdir_p(trace_dir)
       context.tracing.stop(path: trace_path)

--- a/app/models/concerns/upright/playwright/video_recording.rb
+++ b/app/models/concerns/upright/playwright/video_recording.rb
@@ -48,7 +48,16 @@ module Upright::Playwright::VideoRecording
       self.video_artifacts ||= []
       video_artifacts << pending_video_recording.merge(path: video_path)
     ensure
+      delete_source_video
       self.pending_video_recording = nil
+    end
+
+    # Playwright writes its own source file per page; delete it after saving
+    # our copy so page@*.webm recordings don't accumulate on disk.
+    def delete_source_video
+      pending_video_recording&.fetch(:video)&.delete
+    rescue => error
+      Rails.error.report(error)
     end
 
     def attach_video(probe_result)
@@ -65,7 +74,9 @@ module Upright::Playwright::VideoRecording
       if logger.respond_to?(:struct)
         video_artifact = probe_result.artifacts.find { |attached| attached.content_type == "video/webm" }
         if video_artifact
-          logger.struct probe_artifact_url: Rails.application.routes.url_helpers.rails_blob_url(video_artifact, expires_in: 24.hours)
+          # Log the blob key, never a signed URL: signed URLs in logs/OTEL are
+          # bearer credentials for the recording.
+          logger.struct probe_artifact_key: video_artifact.key
         end
       end
 

--- a/app/models/concerns/upright/services/live_status.rb
+++ b/app/models/concerns/upright/services/live_status.rb
@@ -3,6 +3,11 @@ module Upright::Services::LiveStatus
 
   OUTAGE_LOOKBACK = 24.hours
 
+  # Matches the public status page's `expires_in`, so a burst of anonymous
+  # hits costs at most one Prometheus round trip per service per window
+  # instead of amplifying every request into live queries.
+  CACHE_TTL = 15.seconds
+
   def live_status
     Upright::Status.for(live_up_fraction)
   end
@@ -25,20 +30,30 @@ module Upright::Services::LiveStatus
     end
 
     def live_down_fraction
-      response = Upright.prometheus_client.query(
-        query: live_down_query
-      ).deep_symbolize_keys
-      response.dig(:result, 0, :value, 1).to_f
+      cached :live_down_fraction do
+        response = Upright.prometheus_client.query(
+          query: live_down_query
+        ).deep_symbolize_keys
+        response.dig(:result, 0, :value, 1).to_f
+      end
     end
 
+    # Cached without regard to `now:` — a window up to CACHE_TTL stale is
+    # within the freshness the status page already advertises.
     def live_down_history(now:)
-      response = Upright.prometheus_client.query_range(
-        query: live_down_query,
-        start: (now - OUTAGE_LOOKBACK).iso8601,
-        end:   now.iso8601,
-        step:  "300s"
-      ).deep_symbolize_keys
-      response.dig(:result, 0, :values) || []
+      cached :live_down_history do
+        response = Upright.prometheus_client.query_range(
+          query: live_down_query,
+          start: (now - OUTAGE_LOOKBACK).iso8601,
+          end:   now.iso8601,
+          step:  "300s"
+        ).deep_symbolize_keys
+        response.dig(:result, 0, :values) || []
+      end
+    end
+
+    def cached(name, &block)
+      Rails.cache.fetch([ "upright", name, code ], expires_in: CACHE_TTL, &block)
     end
 
     def live_down_query

--- a/app/models/upright/http/request.rb
+++ b/app/models/upright/http/request.rb
@@ -1,4 +1,9 @@
 class Upright::HTTP::Request
+  # Verbose curl output echoes request/response headers and credential lines.
+  # Redact their values before the log is attached as a viewable artifact.
+  SENSITIVE_HEADER = /^(\s*(?:authorization|proxy-authorization|cookie|set-cookie)\s*:\s*)[^\r\n]+/i
+  SENSITIVE_CREDENTIAL = /^(\s*[^\r\n:=]*(?:userpwd|password|credential)[^\r\n:=]*\s*[:=]\s*)[^\r\n]+/i
+
   attr_reader :url, :options
 
   def initialize(url, **options)
@@ -50,10 +55,14 @@ class Upright::HTTP::Request
     def build_log(response)
       StringIO.new.tap do |log|
         if response.debug_info
-          response.debug_info.text.each { |msg| log.puts "* #{msg.chomp}" }
-          response.debug_info.header_out.each { |msg| log.puts "> #{msg.chomp}" }
-          response.debug_info.header_in.each { |msg| log.puts "< #{msg.chomp}" }
+          response.debug_info.text.each { |msg| log.puts "* #{redact(msg.chomp)}" }
+          response.debug_info.header_out.each { |msg| log.puts "> #{redact(msg.chomp)}" }
+          response.debug_info.header_in.each { |msg| log.puts "< #{redact(msg.chomp)}" }
         end
       end
+    end
+
+    def redact(message)
+      message.scrub.gsub(SENSITIVE_HEADER, '\1[REDACTED]').gsub(SENSITIVE_CREDENTIAL, '\1[REDACTED]')
     end
 end

--- a/app/models/upright/incident.rb
+++ b/app/models/upright/incident.rb
@@ -20,6 +20,11 @@ class Upright::Incident < Upright::PersistentRecord
   has_many :updates, -> { order(created_at: :desc) }, class_name: "Upright::IncidentUpdate", inverse_of: :incident, dependent: :destroy
   has_many :affected_services, class_name: "Upright::IncidentAffectedService", inverse_of: :incident, dependent: :destroy
 
+  # An incident is public-facing when it affects at least one public service.
+  # Everything else — internal-only or untagged — stays off the public status
+  # page entirely (fail closed).
+  scope :public_facing, -> { for_service(Upright::Service.public_facing.map(&:code)).distinct }
+
   validates :title, :starts_at, presence: true
   validates :status, inclusion: { in: ->(incident) { incident.class::STATUSES } }
   validates :impact, inclusion: { in: ->(incident) { incident.class::IMPACTS } }
@@ -42,6 +47,10 @@ class Upright::Incident < Upright::PersistentRecord
 
   def services
     service_codes.filter_map { |code| Upright::Service.find_by(code: code) }
+  end
+
+  def public_services
+    services.select { |service| service[:public] }
   end
 
   private

--- a/app/models/upright/probes/http_probe.rb
+++ b/app/models/upright/probes/http_probe.rb
@@ -6,6 +6,11 @@ class Upright::Probes::HTTPProbe < FrozenRecord::Base
 
   DEFAULT_EXPECTED_STATUS = 200..399
 
+  # Response bodies are stored as viewable/downloadable artifacts: cap their
+  # size and never store them as text/html, which would be same-origin XSS.
+  MAX_STORED_BODY_BYTES = 1.megabyte
+  TRUNCATION_NOTICE = "\n\n[TRUNCATED: response body exceeded #{MAX_STORED_BODY_BYTES} bytes]".freeze
+
   attr_accessor :last_response
 
   def check
@@ -100,7 +105,31 @@ class Upright::Probes::HTTPProbe < FrozenRecord::Base
 
     def attach_response_body(probe_result)
       if last_response && last_response.body.present?
-        Upright::Artifact.new(name: "response.#{last_response.file_extension}", content: last_response.body).attach_to(probe_result)
+        # Attach directly with identify: false — the body is untrusted remote
+        # content, and ActiveStorage's content sniffing would otherwise restore
+        # text/html and make the stored artifact same-origin XSS when previewed.
+        probe_result.artifacts.attach(
+          io: StringIO.new(stored_body),
+          filename: "response.#{stored_body_extension}",
+          content_type: stored_body_content_type,
+          identify: false
+        )
+      end
+    end
+
+    def stored_body_extension
+      last_response.file_extension == "html" ? "txt" : last_response.file_extension
+    end
+
+    def stored_body_content_type
+      Marcel::MimeType.for(extension: stored_body_extension)
+    end
+
+    def stored_body
+      if last_response.body.bytesize > MAX_STORED_BODY_BYTES
+        last_response.body.byteslice(0, MAX_STORED_BODY_BYTES) + TRUNCATION_NOTICE
+      else
+        last_response.body
       end
     end
 end

--- a/app/models/upright/service.rb
+++ b/app/models/upright/service.rb
@@ -8,10 +8,12 @@ class Upright::Service < FrozenRecord::Base
 
   scope :public_facing, -> { where(public: true) }
 
-  def self.overall_status
+  # The public status page passes `incidents: Upright::Incident.public_facing`
+  # so internal-only incidents and maintenances never color the public banner.
+  def self.overall_status(incidents: Upright::Incident.all)
     probe_statuses = all.reject(&:maintenance_active?).map(&:live_status)
-    worst = Upright::Status.worst(probe_statuses + Upright::Incident.active_statuses)
-    worst == :operational && Upright::Maintenance.active.any? ? :maintenance : worst
+    worst = Upright::Status.worst(probe_statuses + incidents.active_statuses)
+    worst == :operational && incidents.planned.active.any? ? :maintenance : worst
   end
 
   def self.by_history(past: 90.days)

--- a/app/models/upright/traceroute/ip_metadata_lookup.rb
+++ b/app/models/upright/traceroute/ip_metadata_lookup.rb
@@ -3,7 +3,14 @@ require "json"
 require "resolv"
 
 class Upright::Traceroute::IpMetadataLookup
+  # ip-api.com only offers TLS with a paid key (the free /batch endpoint
+  # rejects HTTPS outright). With IP_API_KEY set, lookups use the TLS pro
+  # endpoint. Without a key they fall back to plain HTTP, which exposes the
+  # looked-up hop IPs to on-path observers — the response is public geo
+  # metadata, but consider a paid key or a local GeoIP database (e.g. maxmind's
+  # GeoLite2 via the maxmind-geoip2 gem) if that leak matters to you.
   API_URL = "http://ip-api.com/batch"
+  TLS_API_URL = "https://pro.ip-api.com/batch"
   TIMEOUT = 5.seconds
   GEOHASH_PRECISION = 6
   CACHE_TTL = 24.hours
@@ -48,12 +55,12 @@ class Upright::Traceroute::IpMetadataLookup
       end
 
       def fetch_batch(ips)
-        uri = URI(API_URL)
+        uri = api_uri
         request = Net::HTTP::Post.new(uri)
         request.content_type = "application/json"
         request.body = ips.to_json
 
-        response = Net::HTTP.start(uri.hostname, uri.port, read_timeout: TIMEOUT, open_timeout: TIMEOUT) do |http|
+        response = Net::HTTP.start(uri.hostname, uri.port, use_ssl: uri.scheme == "https", read_timeout: TIMEOUT, open_timeout: TIMEOUT) do |http|
           http.request(request)
         end
 
@@ -62,6 +69,18 @@ class Upright::Traceroute::IpMetadataLookup
         else
           {}
         end
+      end
+
+      def api_uri
+        if api_key.present?
+          URI("#{TLS_API_URL}?key=#{api_key}")
+        else
+          URI(API_URL)
+        end
+      end
+
+      def api_key
+        ENV["IP_API_KEY"]
       end
 
       def parse_response(results)

--- a/app/models/upright/traceroute/result.rb
+++ b/app/models/upright/traceroute/result.rb
@@ -4,9 +4,10 @@ class Upright::Traceroute::Result
   PROBE_COUNT = 10
   MAX_HOPS = 30
 
-  # Hostnames, IPv4, and IPv6 addresses only. The first character may not be
-  # a dash, so a configured host can never be mistaken for an mtr flag.
-  HOST_PATTERN = /\A[a-z0-9:][a-z0-9:._-]*\z/i
+  # Hostnames, IPv4, and IPv6 addresses (including a link-local zone such as
+  # fe80::1%eth0) only. The first character may not be a dash, so a configured
+  # host can never be mistaken for an mtr flag.
+  HOST_PATTERN = /\A[a-z0-9:][a-z0-9:._-]*(?:%[a-z0-9._-]+)?\z/i
 
   attr_reader :host, :hops, :raw_json
 

--- a/app/models/upright/traceroute/result.rb
+++ b/app/models/upright/traceroute/result.rb
@@ -4,6 +4,10 @@ class Upright::Traceroute::Result
   PROBE_COUNT = 10
   MAX_HOPS = 30
 
+  # Hostnames, IPv4, and IPv6 addresses only. The first character may not be
+  # a dash, so a configured host can never be mistaken for an mtr flag.
+  HOST_PATTERN = /\A[a-z0-9:][a-z0-9:._-]*\z/i
+
   attr_reader :host, :hops, :raw_json
 
   def self.for(host)
@@ -11,6 +15,8 @@ class Upright::Traceroute::Result
   end
 
   def initialize(host)
+    raise ArgumentError, "invalid traceroute host: #{host.inspect}" unless HOST_PATTERN.match?(host.to_s)
+
     @host = host
     @hops = []
   end
@@ -32,7 +38,7 @@ class Upright::Traceroute::Result
         "--aslookup",
         "--report-cycles", PROBE_COUNT.to_s,
         "--max-ttl", MAX_HOPS.to_s,
-        host.to_s
+        "--", host.to_s
       )
 
       Rails.logger.info stdout

--- a/app/views/upright/public/incidents/show.html.erb
+++ b/app/views/upright/public/incidents/show.html.erb
@@ -11,8 +11,8 @@
       <% if @incident.maintenance? %>
         <span><%= local_maintenance_window(@incident) %></span>
       <% end %>
-      <% if @incident.services.any? %>
-        <span><%= @incident.services.map(&:name).to_sentence %></span>
+      <% if @incident.public_services.any? %>
+        <span><%= @incident.public_services.map(&:name).to_sentence %></span>
       <% end %>
     </div>
   </header>

--- a/app/views/upright/public/services/_active_events.html.erb
+++ b/app/views/upright/public/services/_active_events.html.erb
@@ -12,8 +12,8 @@
           <p class="event__meta"><%= local_maintenance_window(event) %></p>
         <% end %>
 
-        <% if event.services.any? %>
-          <p class="event__services"><%= event.services.map(&:name).to_sentence %></p>
+        <% if event.public_services.any? %>
+          <p class="event__services"><%= event.public_services.map(&:name).to_sentence %></p>
         <% end %>
 
         <% if update = event.updates.first %>

--- a/app/views/upright/public/services/_upcoming_maintenance.html.erb
+++ b/app/views/upright/public/services/_upcoming_maintenance.html.erb
@@ -8,8 +8,8 @@
           <span class="upcoming__when"><%= local_maintenance_window(maintenance) %></span>
         </div>
 
-        <% if maintenance.services.any? %>
-          <p class="event__services"><%= maintenance.services.map(&:name).to_sentence %></p>
+        <% if maintenance.public_services.any? %>
+          <p class="event__services"><%= maintenance.public_services.map(&:name).to_sentence %></p>
         <% end %>
 
         <% if (update = maintenance.updates.first) && update.body.present? %>

--- a/app/views/upright/public/services/index.html.erb
+++ b/app/views/upright/public/services/index.html.erb
@@ -1,7 +1,7 @@
 <div class="status-page">
   <h1 class="status-page__title">Status</h1>
 
-  <%= render "overall_banner", status: @services.overall_status %>
+  <%= render "overall_banner", status: @overall_status %>
   <%= render "degraded_list", degraded: @services.degraded %>
 
   <%= render "active_events", incidents: @active_incidents, maintenances: @active_maintenances %>

--- a/app/views/upright/sessions/new.html.erb
+++ b/app/views/upright/sessions/new.html.erb
@@ -1,6 +1,19 @@
 <div class="sign-in-container">
   <div class="sign-in-box">
     <h1>Upright</h1>
-    <%= button_to "Sign in", "/auth/#{Upright.configuration.auth_provider}", method: :post, data: { turbo: false }, class: "btn" %>
+    <% if Upright.configuration.auth_provider.to_sym == :static_credentials %>
+      <%# Post credentials straight to the OmniAuth callback, but as a same-origin
+          form carrying a Rails authenticity token so a cross-site request can't
+          forge a sign-in (CVE-2026-67993). %>
+      <%= form_with url: "/auth/static_credentials/callback", method: :post, data: { turbo: false } do |form| %>
+        <%= form.label :username, "Username" %>
+        <%= form.text_field :username, autocomplete: "username" %>
+        <%= form.label :password, "Password" %>
+        <%= form.password_field :password, autocomplete: "current-password" %>
+        <%= form.submit "Sign in", class: "btn" %>
+      <% end %>
+    <% else %>
+      <%= button_to "Sign in", "/auth/#{Upright.configuration.auth_provider}", method: :post, data: { turbo: false }, class: "btn" %>
+    <% end %>
   </div>
 </div>

--- a/lib/generators/upright/install/install_generator.rb
+++ b/lib/generators/upright/install/install_generator.rb
@@ -17,7 +17,11 @@ module Upright
       def copy_initializers
         template "upright.rb", "config/initializers/upright.rb"
         template "omniauth.rb", "config/initializers/omniauth.rb"
-        template "content_security_policy.rb", "config/initializers/content_security_policy.rb", force: true
+        # Never force: an app may already run an enforced CSP, and silently
+        # replacing it with this commented template would disable it. On a
+        # collision Thor prompts instead of overwriting; the recommended policy is
+        # documented for the operator to merge.
+        template "content_security_policy.rb", "config/initializers/content_security_policy.rb"
       end
 
       def copy_sites_config

--- a/lib/generators/upright/install/install_generator.rb
+++ b/lib/generators/upright/install/install_generator.rb
@@ -17,6 +17,7 @@ module Upright
       def copy_initializers
         template "upright.rb", "config/initializers/upright.rb"
         template "omniauth.rb", "config/initializers/omniauth.rb"
+        template "content_security_policy.rb", "config/initializers/content_security_policy.rb", force: true
       end
 
       def copy_sites_config
@@ -106,7 +107,7 @@ module Upright
         say "  2. Configure your servers in config/deploy.yml"
         say "  3. Configure sites in config/sites.yml"
         say "  4. Add probes in probes/*.yml"
-        say "  5. Set ADMIN_PASSWORD env var (default: upright)"
+        say "  5. Set the ADMIN_PASSWORD env var — required, there is no default password"
         say ""
         say "For production, review config/initializers/upright.rb and update:"
         say "  config.hostname = \"example.com\""

--- a/lib/generators/upright/install/templates/content_security_policy.rb
+++ b/lib/generators/upright/install/templates/content_security_policy.rb
@@ -1,0 +1,43 @@
+# Be sure to restart your server when you modify this file.
+
+# Content Security Policy tuned for Upright. Uncomment the block below to
+# enforce it. Every source the engine actually uses is listed explicitly:
+#
+#   * JavaScript dependencies (Turbo, Stimulus, Leaflet, Frappe Charts) are
+#     pinned to https://cdn.jsdelivr.net in the engine's config/importmap.rb.
+#   * The Leaflet stylesheet is loaded from https://unpkg.com in the engine
+#     layout; Turbo injects an inline <style> for its progress bar, which is
+#     why style-src keeps :unsafe_inline (styles only — scripts stay strict).
+#   * Map tiles come from OpenStreetMap (light) and Carto (dark); Leaflet's
+#     default marker icons load from unpkg alongside its stylesheet.
+#   * The inline <script type="importmap"> tag is authorized by a per-session
+#     nonce via csp_meta_tag, which the engine layouts already render.
+#
+# To verify without breaking anything, start with
+# config.content_security_policy_report_only = true and watch the browser
+# console before enforcing.
+
+# Rails.application.configure do
+#   config.content_security_policy do |policy|
+#     policy.default_src     :self
+#     policy.font_src        :self, :data
+#     policy.img_src         :self, :data, "https://unpkg.com",
+#                            "https://*.tile.openstreetmap.org",
+#                            "https://*.basemaps.cartocdn.com"
+#     policy.object_src      :none
+#     policy.script_src      :self, "https://cdn.jsdelivr.net"
+#     policy.style_src       :self, :unsafe_inline, "https://unpkg.com"
+#     policy.connect_src     :self
+#     policy.frame_ancestors :self
+#     policy.base_uri        :self
+#     # Specify URI for violation reports
+#     # policy.report_uri "/csp-violation-report-endpoint"
+#   end
+#
+#   # Generate session nonces for the inline importmap script tag.
+#   config.content_security_policy_nonce_generator = ->(request) { request.session.id.to_s }
+#   config.content_security_policy_nonce_directives = %w(script-src)
+#
+#   # Report violations without enforcing the policy.
+#   # config.content_security_policy_report_only = true
+# end

--- a/lib/generators/upright/install/templates/deploy.yml
+++ b/lib/generators/upright/install/templates/deploy.yml
@@ -48,6 +48,7 @@ env:
   secret:
     - RAILS_MASTER_KEY
     - PROMETHEUS_OTLP_TOKEN
+    - ADMIN_PASSWORD
   tags:
     london:
       SITE_SUBDOMAIN: lon
@@ -62,7 +63,13 @@ volumes:
 
 accessories:
   otel_collector:
-    image: otel/opentelemetry-collector-contrib:0.126.0
+    # Pinned by digest so deploys are immutable; the tag is documentation only.
+    image: otel/opentelemetry-collector-contrib:0.126.0@sha256:973747f78266a8ffec428417727e6b704559e9a30e4be8c1cca2899facd68689
+    # The collector runs unprivileged and only receives OTLP over the private
+    # Docker network — it does not mount the Docker socket or host log
+    # directories. To collect container logs, prefer a filelog receiver over
+    # a read-only mount of the specific log path rather than the Docker socket,
+    # which grants root-equivalent control of the host.
     env:
       secret:
         - OTEL_GATEWAY_USERNAME
@@ -71,11 +78,6 @@ accessories:
         - PROMETHEUS_OTLP_TOKEN
     files:
       - config/otel_collector.yml:/etc/otelcol-contrib/config.yaml
-    volumes:
-      - /var/run/docker.sock:/var/run/docker.sock
-      - /var/lib/docker/containers:/var/lib/docker/containers
-    options:
-      user: 0
     roles:
       - jobs
 
@@ -83,12 +85,16 @@ accessories:
     image: prom/prometheus:v3.2.1
     hosts:
       - <%= app_domain %>
+    # No published port: Prometheus is only reachable over the private Docker
+    # network (the app proxies it). --web.enable-lifecycle is deliberately
+    # omitted — the unauthenticated reload/quit endpoints aren't needed since
+    # config changes redeploy the accessory; if you add it back, front it with
+    # --web.config.file authentication.
     cmd: >-
       --config.file=/etc/prometheus/prometheus.yml
       --storage.tsdb.path=/prometheus
       --storage.tsdb.retention.time=30d
       --web.enable-otlp-receiver
-      --web.enable-lifecycle
     files:
       - config/prometheus/prometheus.yml:/etc/prometheus/prometheus.yml
       - config/prometheus/rules/upright.rules.yml:/etc/prometheus/rules/upright.rules.yml

--- a/lib/generators/upright/install/templates/docker-compose.yml
+++ b/lib/generators/upright/install/templates/docker-compose.yml
@@ -10,14 +10,19 @@ services:
     command:
       - '--config.file=/etc/prometheus/prometheus.yml'
       - '--storage.tsdb.path=/prometheus'
-      - '--web.enable-lifecycle'
+      # Host networking would otherwise listen on all interfaces; keep the
+      # dev server loopback-only. --web.enable-lifecycle is deliberately
+      # omitted — its unauthenticated reload/quit endpoints aren't needed
+      # (restart the container to reload config); if you add it back, pair
+      # it with --web.config.file authentication.
+      - '--web.listen-address=127.0.0.1:9090'
       - '--web.enable-remote-write-receiver'
 
   alertmanager:
     image: prom/alertmanager:v0.28.1
     container_name: <%= app_name %>-alertmanager
     ports:
-      - "9093:9093"
+      - "127.0.0.1:9093:9093"
     volumes:
       - ./config/alertmanager/development/alertmanager.yml:/etc/alertmanager/alertmanager.yml:ro
       - alertmanager_data:/alertmanager

--- a/lib/generators/upright/install/templates/omniauth.rb
+++ b/lib/generators/upright/install/templates/omniauth.rb
@@ -1,8 +1,12 @@
-# WARNING: Change the default password before deploying to production!
-# Set the ADMIN_PASSWORD environment variable or update the credentials below.
+# Set ADMIN_PASSWORD to enable the built-in admin login. When it is unset the
+# static credential is left unconfigured (fail closed) so the app never ships a
+# well-known default password. Change the username/credentials below to suit, or
+# switch to an external provider (e.g. OpenID Connect) via config.auth_provider.
+
+admin_password = ENV["ADMIN_PASSWORD"].presence
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :static_credentials,
     title: "Sign In",
-    credentials: { "admin" => ENV.fetch("ADMIN_PASSWORD", "upright") }
+    credentials: admin_password ? { "admin" => admin_password } : {}
 end

--- a/lib/generators/upright/install/templates/otel_collector.yml
+++ b/lib/generators/upright/install/templates/otel_collector.yml
@@ -2,6 +2,12 @@ receivers:
   otlp:
     protocols:
       http:
+        # The app container reaches the collector over the private Docker
+        # network, so the receiver must listen on a non-loopback interface.
+        # Kamal does not publish this port to the host (no `port:` on the
+        # accessory), so it is only reachable from containers on that network.
+        # If you ever publish it, bind a specific internal interface instead
+        # of 0.0.0.0 and require authentication.
         endpoint: 0.0.0.0:4318
 
 processors:

--- a/lib/generators/upright/install/templates/recurring.yml
+++ b/lib/generators/upright/install/templates/recurring.yml
@@ -24,6 +24,10 @@ production:
     command: "Upright::ProbeResult.cleanup_stale"
     schedule: every hour at minute 30
 
+  sweep_playwright_videos:
+    class: "Upright::PlaywrightVideoSweepJob"
+    schedule: every hour at minute 45
+
   health_metrics:
     class: "Upright::HealthMetricsJob"
     schedule: every minute

--- a/lib/generators/upright/install/templates/upright.rb
+++ b/lib/generators/upright/install/templates/upright.rb
@@ -8,6 +8,14 @@ Upright.configure do |config|
   # Playwright CLI path (defaults to "npx playwright", override with PLAYWRIGHT_CLI_PATH env var)
   # config.playwright_cli_path = "npx playwright"
 
+  # Token authenticating machine callers: collectors writing metrics and jobs
+  # reading a peer site's /prometheus and /alertmanager proxies. Randomly
+  # generated at install time — every site must share the same value, so treat
+  # it like any other secret when adding sites. Set the PROMETHEUS_OTLP_TOKEN
+  # env var (already wired as a Kamal secret in config/deploy.yml) to rotate it
+  # without editing this file.
+  config.proxy_token = ENV.fetch("PROMETHEUS_OTLP_TOKEN", "<%= SecureRandom.hex(32) %>")
+
   # OpenTelemetry endpoint
   # config.otel_endpoint = ENV["OTEL_EXPORTER_OTLP_ENDPOINT"]
 

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -173,11 +173,6 @@ class Upright::Configuration
         hosts << /\A#{Regexp.escape(domain)}#{port_suffix}\z/
       end
       Rails.application.config.hosts = hosts
-      # Derive tld_length from the configured hostname's depth rather than forcing
-      # 1. This keeps subdomain parsing correct for multi-label hostnames and, for
-      # `domain: :all` session cookies, scopes the cookie to `.#{hostname}` instead
-      # of the registrable parent — so a sibling like evil.example.com can't be
-      # handed the admin session when the app runs at upright.example.com (F-08).
-      Rails.application.config.action_dispatch.tld_length = hostname.count(".")
+      Rails.application.config.action_dispatch.tld_length = 1
     end
 end

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -173,6 +173,11 @@ class Upright::Configuration
         hosts << /\A#{Regexp.escape(domain)}#{port_suffix}\z/
       end
       Rails.application.config.hosts = hosts
-      Rails.application.config.action_dispatch.tld_length = 1
+      # Derive tld_length from the configured hostname's depth rather than forcing
+      # 1. This keeps subdomain parsing correct for multi-label hostnames and, for
+      # `domain: :all` session cookies, scopes the cookie to `.#{hostname}` instead
+      # of the registrable parent — so a sibling like evil.example.com can't be
+      # handed the admin session when the app runs at upright.example.com (F-08).
+      Rails.application.config.action_dispatch.tld_length = hostname.count(".")
     end
 end

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -6,9 +6,15 @@ class Upright::Engine < ::Rails::Engine
 
   # Session store configuration
   initializer "upright.session_store", before: :load_config_initializers do |app|
+    # Scope the cookie to the configured hostname (resolved per-request, since the
+    # host app sets it in an initializer that runs after this one) rather than
+    # `domain: :all`, which — with a multi-label hostname like upright.example.com
+    # — would hand the cookie to the registrable parent and every sibling under it
+    # (F-08). This is independent of tld_length, so custom status domains still
+    # parse normally.
     app.config.session_store :cookie_store,
       key: "_upright_session",
-      domain: :all,
+      domain: ->(_request) { Upright.configuration.hostname&.then { |h| ".#{h}" } },
       same_site: :lax,
       secure: !Rails.env.local?,
       httponly: true,

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -11,7 +11,17 @@ class Upright::Engine < ::Rails::Engine
       domain: :all,
       same_site: :lax,
       secure: !Rails.env.local?,
+      httponly: true,
       expire_after: 24.hours
+  end
+
+  # The proxy token stands in for an admin session on the metrics proxies, so a
+  # blank one in a deployed environment is a fail-open: any bearer value would be
+  # compared against "" . Refuse to boot without one outside local envs.
+  config.after_initialize do
+    if !Rails.env.local? && Upright.configuration.proxy_token.blank?
+      raise Upright::ConfigurationError, "Upright.configuration.proxy_token (or PROMETHEUS_OTLP_TOKEN) must be set outside development/test"
+    end
   end
 
   config.after_initialize do

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -17,9 +17,13 @@ class Upright::Engine < ::Rails::Engine
 
   # The proxy token stands in for an admin session on the metrics proxies, so a
   # blank one in a deployed environment is a fail-open: any bearer value would be
-  # compared against "" . Refuse to boot without one outside local envs.
+  # compared against "" . Refuse to boot without one outside local envs — but not
+  # during `assets:precompile`, which Rails runs with SECRET_KEY_BASE_DUMMY and no
+  # runtime secrets (the Docker image builds before the token is available).
   config.after_initialize do
-    if !Rails.env.local? && Upright.configuration.proxy_token.blank?
+    building_assets = ENV["SECRET_KEY_BASE_DUMMY"].present?
+
+    if !Rails.env.local? && !building_assets && Upright.configuration.proxy_token.blank?
       raise Upright::ConfigurationError, "Upright.configuration.proxy_token (or PROMETHEUS_OTLP_TOKEN) must be set outside development/test"
     end
   end

--- a/test/dummy/config/recurring.yml
+++ b/test/dummy/config/recurring.yml
@@ -32,6 +32,10 @@ production:
     command: "Upright::ProbeResult.cleanup_stale"
     schedule: every hour at minute 30
 
+  sweep_playwright_videos:
+    class: "Upright::PlaywrightVideoSweepJob"
+    schedule: every hour at minute 45
+
   aggregate_rollups:
     class: "Upright::Rollups::DailyAggregationJob"
     schedule: every hour at minute 5

--- a/test/dummy/probes/ping_probe.rb
+++ b/test/dummy/probes/ping_probe.rb
@@ -4,8 +4,14 @@ class PingProbe < FrozenRecord::Base
 
   stagger_by_site 3.seconds
 
+  # Hostnames, IPv4, and IPv6 addresses only. The first character may not be
+  # a dash, so a configured host can never be mistaken for a ping flag.
+  HOST_PATTERN = /\A[a-z0-9:][a-z0-9:._-]*\z/i
+
   def check
-    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", host)
+    raise ArgumentError, "invalid ping host: #{host.inspect}" unless HOST_PATTERN.match?(host.to_s)
+
+    @ping_output, status = Open3.capture2e("ping", "-c", "1", "-W", "5", "--", host)
     status.success?
   end
 

--- a/test/fixtures/upright_incident_affected_services.yml
+++ b/test/fixtures/upright_incident_affected_services.yml
@@ -4,3 +4,7 @@ _fixture:
 reactive_with_service_app:
   incident: reactive_with_service
   service_code: example_app
+
+reactive_resolved_app:
+  incident: reactive_resolved
+  service_code: example_app

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -11,7 +11,7 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: "Alertmanager UI")
 
     sign_in
-    get "/alertmanager"
+    get "/alertmanager", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end
@@ -21,7 +21,7 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
     sign_in
     on_subdomain :ams
 
-    get "/alertmanager/api/v2/status"
+    get "/alertmanager/api/v2/status", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end
@@ -41,7 +41,7 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
     sign_in
     on_subdomain :nyc
 
-    get "/alertmanager"
+    get "/alertmanager", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :not_found
   end

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -54,7 +54,8 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
 
     sign_in
-    post "/alertmanager/api/v2/silences", params: silence_json, headers: { "Content-Type" => "application/json" }
+    post "/alertmanager/api/v2/silences", params: silence_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
     assert_requested stub

--- a/test/integration/artifacts_controller_test.rb
+++ b/test/integration/artifacts_controller_test.rb
@@ -27,6 +27,18 @@ class ArtifactsControllerTest < ActionDispatch::IntegrationTest
     assert_select "source[src*='rails/active_storage/blobs']"
   end
 
+  test "returns 404 for attachments that do not belong to probe results" do
+    foreign_attachment = ActiveStorage::Attachment.create!(
+      name: "artifacts",
+      record: upright_incidents(:upcoming),
+      blob: active_storage_blobs(:http_log)
+    )
+
+    get upright.site_artifact_path(foreign_attachment)
+
+    assert_response :not_found
+  end
+
   test "redirects to authentication when not signed in" do
     sign_out
     attachment = active_storage_attachments(:http_artifact)

--- a/test/integration/login_csrf_test.rb
+++ b/test/integration/login_csrf_test.rb
@@ -1,0 +1,58 @@
+require "test_helper"
+
+# Regression coverage for CVE-2026-67993 (login CSRF via the static_credentials
+# callback). These tests must run with request forgery protection ENABLED — the
+# suite otherwise disables it (see test/dummy/config/environments/test.rb), which
+# would make every assertion below pass for the wrong reason.
+class LoginCsrfTest < ActionDispatch::IntegrationTest
+  setup do
+    on_subdomain :app
+
+    @forgery_protection_was = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    # test_mode lets us stand in a "valid" credential result without depending on
+    # the configured password: the point under test is that CSRF/method guards
+    # refuse the forged request even when the credentials would have been accepted.
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:static_credentials] = OmniAuth::AuthHash.new(
+      provider: "static_credentials",
+      uid: "admin",
+      info: { email: "admin@localhost", name: "admin" }
+    )
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @forgery_protection_was
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:static_credentials] = nil
+  end
+
+  test "a cross-site GET to the credential callback cannot plant a session" do
+    get "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :not_found
+    assert_nil session[:user_info]
+  end
+
+  test "a cross-origin POST without a valid authenticity token is refused" do
+    post "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :unprocessable_content
+    assert_nil session[:user_info]
+  end
+
+  test "the same-origin sign-in form still signs in" do
+    get upright.new_admin_session_path
+    assert_response :success
+
+    token = css_select("input[name='authenticity_token']").first&.[]("value")
+    assert token.present?, "the sign-in form should carry a Rails authenticity token"
+
+    post "/auth/static_credentials/callback",
+      params: { username: "admin", password: "irrelevant-in-test-mode", authenticity_token: token }
+
+    assert_redirected_to upright.root_path
+    assert session[:user_info].present?
+  end
+end

--- a/test/integration/login_csrf_test.rb
+++ b/test/integration/login_csrf_test.rb
@@ -35,6 +35,13 @@ class LoginCsrfTest < ActionDispatch::IntegrationTest
     assert_nil session[:user_info]
   end
 
+  test "a HEAD to the credential callback cannot plant a session" do
+    head "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :not_found
+    assert_nil session[:user_info]
+  end
+
   test "a cross-origin POST without a valid authenticity token is refused" do
     post "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
 

--- a/test/integration/prometheus_proxy_controller_test.rb
+++ b/test/integration/prometheus_proxy_controller_test.rb
@@ -11,7 +11,7 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
     stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
     sign_in
 
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end
@@ -30,7 +30,7 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
     sign_in
     on_subdomain :ams
 
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end
@@ -66,13 +66,13 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
     sign_in
     on_subdomain :nyc
 
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :not_found
   end
 
   test "proxy requires authentication" do
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :redirect
     assert response.location.end_with?("/session/new")

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -1,0 +1,87 @@
+require "test_helper"
+require "webmock/minitest"
+
+# Regression coverage for CVE-2026-67990 (proxy CSRF). A browser request on the
+# session-cookie path must be refused when it originates cross-site, so a forged
+# request can't ride the victim's Lax session cookie into upstream write/admin
+# APIs. The bearer-token path (automation) stays exempt, and genuine same-origin
+# calls from the embedded UI still forward.
+class ProxyCsrfTest < ActionDispatch::IntegrationTest
+  setup do
+    on_subdomain :ams
+    ENV["PROMETHEUS_OTLP_TOKEN"] = "test-token"
+  end
+
+  # --- The forged cross-site vectors are refused, POST and the Lax-cookie GET ---
+
+  test "cross-site POST to alertmanager on the session path is forbidden" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "forged" }.to_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "cross-site GET to prometheus on the session path is forbidden" do
+    stub = stub_request(:get, "http://localhost:9090/-/reload")
+    sign_in
+
+    # Top-level Lax-cookie navigation vector: a cross-site GET carries no Origin
+    # header, only Sec-Fetch-Site.
+    get "/prometheus/-/reload", headers: { "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "foreign Origin on the session path is forbidden when Sec-Fetch is absent" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "forged" }.to_json,
+      headers: { "Content-Type" => "application/json", "Origin" => "https://evil.example" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  # --- Legitimate traffic still forwards ---
+
+  test "same-origin session request forwards to prometheus" do
+    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+    sign_in
+
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+  end
+
+  test "same-origin session request forwards a write to alertmanager" do
+    silence_json = { comment: "real" }.to_json
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+      .with(body: silence_json)
+      .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: silence_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+    assert_requested stub
+  end
+
+  test "token-authenticated automation is exempt from the cross-site check" do
+    stub_request(:get, "http://localhost:9090/api/v1/query?query=up").to_return(status: 200, body: "{}")
+
+    get "/prometheus/api/v1/query?query=up",
+      headers: { "Authorization" => "Bearer test-token", "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :success
+  end
+end

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -63,6 +63,54 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested stub
   end
 
+  test "Rails token verification stays in the chain as a backstop for the gate" do
+    # The gate refuses cross-site requests before verification is consulted. This
+    # asserts the second layer is still there: with the gate out of the way, a
+    # session POST carrying neither an authenticity token nor same-origin
+    # provenance is still refused rather than forwarded.
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    Upright::AlertmanagerProxyController.any_instance.stubs(:block_cross_site_session_requests)
+    sign_in
+
+    with_forgery_protection do
+      post "/alertmanager/api/v2/silences",
+        params: { comment: "forged" }.to_json,
+        headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "cross-site" }
+    end
+
+    assert_response 422
+    assert_not_requested stub
+  end
+
+  test "a same-origin session POST is verified without an authenticity token" do
+    silence_json = { comment: "real" }.to_json
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+      .with(body: silence_json)
+      .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
+    sign_in
+
+    with_forgery_protection do
+      post "/alertmanager/api/v2/silences",
+        params: silence_json,
+        headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-origin" }
+    end
+
+    assert_response :success
+    assert_requested stub
+  end
+
+  test "a token-authenticated write is verified without an authenticity token" do
+    stub = stub_request(:post, "http://localhost:9090/api/v1/otlp/v1/metrics").to_return(status: 200)
+
+    with_forgery_protection do
+      post "/prometheus/api/v1/otlp/v1/metrics",
+        headers: { "Authorization" => "Bearer test-token", "Content-Type" => "application/x-protobuf" }
+    end
+
+    assert_response :success
+    assert_requested stub
+  end
+
   test "a non-bearer Authorization header buys no exemption from the gate" do
     stub = stub_request(:get, "http://localhost:9090/-/reload")
     sign_in

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -121,13 +121,14 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested reload
   end
 
-  test "a same-site top-level GET navigation between our subdomains is allowed" do
-    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+  test "a same-site request is refused (a sibling domain is same-site, not same-origin)" do
+    stub = stub_request(:get, "http://localhost:9090/graph")
     sign_in
 
     get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "navigate" }
 
-    assert_response :success
+    assert_response :forbidden
+    assert_not_requested stub
   end
 
   # --- WP1: SSRF path lock (F-01 / CVE-2026-25765). The path-authority-override

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -84,4 +84,62 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
 
     assert_response :success
   end
+
+  # --- WP4: tightened Fetch-Metadata policy ---
+
+  test "same-site sub-resource POST is refused" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "sibling" }.to_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "cors" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "a session POST with no Fetch-Metadata and no Origin fails closed" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "old browser" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "a same-site top-level GET navigation between our subdomains is allowed" do
+    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+    sign_in
+
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "navigate" }
+
+    assert_response :success
+  end
+
+  # --- WP1: SSRF path lock (F-01 / CVE-2026-25765). The path-authority-override
+  # vector lives at the Faraday layer (Rack collapses a literal `//` before the
+  # controller), so the sanitizer is unit-tested directly in
+  # proxy_path_sanitization_test.rb. Here we cover the token/forwarding behaviour. ---
+
+  test "a token cannot drive a destructive upstream endpoint" do
+    reload = stub_request(:get, "http://localhost:9090/-/reload")
+
+    get "/prometheus/-/reload", headers: { "Authorization" => "Bearer test-token" }
+
+    assert_response :forbidden
+    assert_not_requested reload
+  end
+
+  test "a normal query still forwards on the session path" do
+    stub_request(:get, "http://localhost:9090/api/v1/query?query=up").to_return(status: 200, body: "{}")
+    sign_in
+
+    get "/prometheus/api/v1/query?query=up", headers: { "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+  end
 end

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -50,6 +50,30 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested stub
   end
 
+  test "a null Origin on the session path is forbidden when Sec-Fetch is absent" do
+    # A sandboxed iframe or a cross-origin redirect sends `Origin: null`.
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "forged" }.to_json,
+      headers: { "Content-Type" => "application/json", "Origin" => "null" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "a non-bearer Authorization header buys no exemption from the gate" do
+    stub = stub_request(:get, "http://localhost:9090/-/reload")
+    sign_in
+
+    get "/prometheus/-/reload",
+      headers: { "Authorization" => "Basic #{Base64.strict_encode64("user:pass")}", "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
   # --- Legitimate traffic still forwards ---
 
   test "same-origin session request forwards to prometheus" do

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -111,6 +111,16 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested stub
   end
 
+  test "a session GET with no provenance headers fails closed" do
+    reload = stub_request(:get, "http://localhost:9090/-/reload")
+    sign_in
+
+    get "/prometheus/-/reload"
+
+    assert_response :forbidden
+    assert_not_requested reload
+  end
+
   test "a same-site top-level GET navigation between our subdomains is allowed" do
     stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
     sign_in

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -1,59 +1,72 @@
 require "test_helper"
 
-# Unit coverage for the proxy path lock (WP1 / F-01 / CVE-2026-25765). These
-# assert the sanitizer directly because the Rack test client (like production
+# Unit coverage for the proxy upstream URL builder (WP1 / F-01 / CVE-2026-25765).
+# These assert the builder directly because the Rack test client (like production
 # path normalization) can collapse a literal `//`, so the authority-override
 # vector is only faithfully exercised against the method itself.
 class ProxyPathSanitizationTest < ActiveSupport::TestCase
+  UPSTREAM = "http://localhost:9090"
+
   setup { @controller = Upright::PrometheusProxyController.new }
 
-  def sanitize(raw)
-    @controller.send(:sanitized_upstream_path, raw)
+  def build(raw)
+    @controller.send(:upstream_url, UPSTREAM, raw)&.to_s
+  end
+
+  test "the upstream host and port always come from the configuration" do
+    # Even a path that survives validation can only ever be a path on the
+    # configured upstream — there is no request input for scheme/host/port.
+    assert_equal "#{UPSTREAM}/api/v1/query", build("/api/v1/query")
   end
 
   test "rejects a protocol-relative authority override" do
-    assert_nil sanitize("//evil.example/steal")
-    assert_nil sanitize("//169.254.169.254/latest/meta-data/")
+    assert_nil build("//evil.example/steal")
+    assert_nil build("//169.254.169.254/latest/meta-data/")
   end
 
   test "rejects path traversal" do
-    assert_nil sanitize("/api/v1/../../etc/passwd")
-    assert_nil sanitize("/..")
+    assert_nil build("/api/v1/../../etc/passwd")
+    assert_nil build("/..")
   end
 
   test "rejects characters outside the path set" do
-    assert_nil sanitize("/api/v1/query\nHost: evil")
-    assert_nil sanitize("/api/ query")
+    assert_nil build("/api/v1/query\nHost: evil")
+    assert_nil build("/api/ query")
+  end
+
+  test "rejects a path with a null byte or broken encoding" do
+    assert_nil build("/api/v1/query\0")
+    assert_nil build("/api/\xC3(")
   end
 
   test "rejects percent-encoding in the path (double-encoding bypass)" do
     # %2f%2f -> // and %252f%252f -> %2f%2f -> // once the upstream decodes it;
     # rejecting any encoding in the path stops the authority/prefix bypass.
-    assert_nil sanitize("/%2f%2fevil.example/steal")
-    assert_nil sanitize("/%252d%252freload")
-    assert_nil sanitize("/api/%2e%2e/secret")
+    assert_nil build("/%2f%2fevil.example/steal")
+    assert_nil build("/%252d%252freload")
+    assert_nil build("/api/%2e%2e/secret")
   end
 
-  test "rejects a single-dot segment that URI#merge would collapse" do
+  test "rejects a single-dot segment that a normalizing hop would collapse" do
     # /./-/reload -> /-/reload after normalization, bypassing the /-/ deny.
-    assert_nil sanitize("/./-/reload")
-    assert_nil sanitize("/api/./v1")
-    assert_nil sanitize("/.")
-    assert_equal "/api/v1.json", sanitize("/api/v1.json") # a dot inside a segment is fine
+    assert_nil build("/./-/reload")
+    assert_nil build("/api/./v1")
+    assert_nil build("/.")
+    assert_equal "#{UPSTREAM}/api/v1.json", build("/api/v1.json") # a dot inside a segment is fine
   end
 
   test "rejects an over-long query" do
-    assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyAuthentication::MAX_UPSTREAM_QUERY + 1)))
+    assert_nil build("/api/v1/query?" + ("a" * (Upright::ProxyAuthentication::MAX_UPSTREAM_QUERY + 1)))
+  end
+
+  test "rejects a malformed percent escape in the query" do
+    assert_nil build("/api/v1/query?query=%zz")
   end
 
   test "passes a normal path and query through unchanged" do
-    assert_equal "/api/v1/query?query=up", sanitize("/api/v1/query?query=up")
-    assert_equal "/graph", sanitize("/graph")
-    assert_equal "/", sanitize("")
-  end
-
-  test "the built request must stay on the configured upstream host" do
-    assert @controller.send(:upstream_host_ok?, "http://localhost:9090", "/api/v1/query")
-    refute @controller.send(:upstream_host_ok?, "http://localhost:9090", "//evil.example/x")
+    assert_equal "#{UPSTREAM}/api/v1/query?query=up", build("/api/v1/query?query=up")
+    assert_equal "#{UPSTREAM}/graph", build("/graph")
+    assert_equal "#{UPSTREAM}/graph/", build("/graph/")
+    assert_equal "#{UPSTREAM}/", build("")
   end
 end

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+# Unit coverage for the proxy path lock (WP1 / F-01 / CVE-2026-25765). These
+# assert the sanitizer directly because the Rack test client (like production
+# path normalization) can collapse a literal `//`, so the authority-override
+# vector is only faithfully exercised against the method itself.
+class ProxyPathSanitizationTest < ActiveSupport::TestCase
+  setup { @controller = Upright::PrometheusProxyController.new }
+
+  def sanitize(raw)
+    @controller.send(:sanitized_upstream_path, raw)
+  end
+
+  test "rejects a protocol-relative authority override" do
+    assert_nil sanitize("//evil.example/steal")
+    assert_nil sanitize("//169.254.169.254/latest/meta-data/")
+  end
+
+  test "rejects path traversal" do
+    assert_nil sanitize("/api/v1/../../etc/passwd")
+    assert_nil sanitize("/..")
+  end
+
+  test "rejects characters outside the path set" do
+    assert_nil sanitize("/api/v1/query\nHost: evil")
+    assert_nil sanitize("/api/ query")
+  end
+
+  test "rejects an over-long query" do
+    assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyAuthentication::MAX_UPSTREAM_QUERY + 1)))
+  end
+
+  test "passes a normal path and query through unchanged" do
+    assert_equal "/api/v1/query?query=up", sanitize("/api/v1/query?query=up")
+    assert_equal "/graph", sanitize("/graph")
+    assert_equal "/", sanitize("")
+  end
+
+  test "the built request must stay on the configured upstream host" do
+    assert @controller.send(:upstream_host_ok?, "http://localhost:9090", "/api/v1/query")
+    refute @controller.send(:upstream_host_ok?, "http://localhost:9090", "//evil.example/x")
+  end
+end

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -34,6 +34,14 @@ class ProxyPathSanitizationTest < ActiveSupport::TestCase
     assert_nil sanitize("/api/%2e%2e/secret")
   end
 
+  test "rejects a single-dot segment that URI#merge would collapse" do
+    # /./-/reload -> /-/reload after normalization, bypassing the /-/ deny.
+    assert_nil sanitize("/./-/reload")
+    assert_nil sanitize("/api/./v1")
+    assert_nil sanitize("/.")
+    assert_equal "/api/v1.json", sanitize("/api/v1.json") # a dot inside a segment is fine
+  end
+
   test "rejects an over-long query" do
     assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyAuthentication::MAX_UPSTREAM_QUERY + 1)))
   end

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -26,6 +26,14 @@ class ProxyPathSanitizationTest < ActiveSupport::TestCase
     assert_nil sanitize("/api/ query")
   end
 
+  test "rejects percent-encoding in the path (double-encoding bypass)" do
+    # %2f%2f -> // and %252f%252f -> %2f%2f -> // once the upstream decodes it;
+    # rejecting any encoding in the path stops the authority/prefix bypass.
+    assert_nil sanitize("/%2f%2fevil.example/steal")
+    assert_nil sanitize("/%252d%252freload")
+    assert_nil sanitize("/api/%2e%2e/secret")
+  end
+
   test "rejects an over-long query" do
     assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyAuthentication::MAX_UPSTREAM_QUERY + 1)))
   end

--- a/test/integration/public/incidents_controller_test.rb
+++ b/test/integration/public/incidents_controller_test.rb
@@ -12,4 +12,36 @@ class Upright::Public::IncidentsControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_no_match(/Lewis Buckley/, response.body)
   end
+
+  test "returns 404 for an incident that affects only internal services" do
+    incident = declare_incident title: "Internal tools are down", service_codes: [ "internal_tools" ]
+
+    get upright.public_incident_path(incident)
+
+    assert_response :not_found
+  end
+
+  test "returns 404 for an incident not tagged with any service" do
+    incident = declare_incident title: "Untagged incident"
+
+    get upright.public_incident_path(incident)
+
+    assert_response :not_found
+  end
+
+  test "shows a public-facing incident without naming its internal services" do
+    incident = declare_incident title: "Widespread slowness", service_codes: [ "example_app", "internal_tools" ]
+
+    get upright.public_incident_path(incident)
+
+    assert_response :success
+    assert_match "Example App", response.body
+    assert_no_match(/Internal Tools/, response.body)
+  end
+
+  private
+    def declare_incident(title:, service_codes: [])
+      Upright::Incident.create! title: title, impact: "critical",
+        starts_at: 1.hour.ago, service_codes: service_codes
+    end
 end

--- a/test/integration/public/services_controller_test.rb
+++ b/test/integration/public/services_controller_test.rb
@@ -24,4 +24,56 @@ class Upright::Public::ServicesControllerTest < ActionDispatch::IntegrationTest
     assert_match "<title>Upright Status</title>", response.body
     assert_match "<channel>", response.body
   end
+
+  test "index shows incidents affecting public services and hides internal-only or untagged ones" do
+    raise_public_incident
+    raise_internal_incident
+
+    get upright.public_services_root_path
+
+    assert_response :success
+    assert_match "Example App is on fire", response.body
+    assert_no_match(/Internal tools are down/, response.body)
+    assert_no_match(/Rolling restart/, response.body) # active maintenance not tagged to a public service
+  end
+
+  test "an internal-only incident does not change the overall status banner" do
+    raise_internal_incident impact: "critical"
+
+    get upright.public_services_root_path
+
+    assert_response :success
+    assert_match "All Systems Operational", response.body
+  end
+
+  test "a public-facing incident raises the overall status banner" do
+    raise_public_incident impact: "critical"
+
+    get upright.public_services_root_path
+
+    assert_response :success
+    assert_match "Major Outage", response.body
+  end
+
+  test "feed only carries incidents affecting public services" do
+    raise_public_incident
+    raise_internal_incident
+
+    get upright.public_services_feed_path
+
+    assert_response :success
+    assert_match "Example App is on fire", response.body
+    assert_no_match(/Internal tools are down/, response.body)
+  end
+
+  private
+    def raise_public_incident(impact: "major")
+      Upright::Incident.create! title: "Example App is on fire", impact: impact,
+        starts_at: 1.hour.ago, service_codes: [ "example_app" ]
+    end
+
+    def raise_internal_incident(impact: "critical")
+      Upright::Incident.create! title: "Internal tools are down", impact: impact,
+        starts_at: 1.hour.ago, service_codes: [ "internal_tools" ]
+    end
 end

--- a/test/integration/public/services_controller_test.rb
+++ b/test/integration/public/services_controller_test.rb
@@ -66,6 +66,19 @@ class Upright::Public::ServicesControllerTest < ActionDispatch::IntegrationTest
     assert_no_match(/Internal tools are down/, response.body)
   end
 
+  test "upcoming maintenance affecting a mix of services names only the public ones" do
+    Upright::Maintenance.create! title: "Planned failover", impact: "maintenance",
+      starts_at: 1.hour.from_now, ends_at: 2.hours.from_now,
+      service_codes: [ "example_app", "internal_tools" ]
+
+    get upright.public_services_root_path
+
+    assert_response :success
+    assert_match "Planned failover", response.body
+    assert_match "Example App", response.body
+    assert_no_match(/Internal Tools/, response.body)
+  end
+
   private
     def raise_public_incident(impact: "major")
       Upright::Incident.create! title: "Example App is on fire", impact: impact,

--- a/test/integration/sessions_controller_test.rb
+++ b/test/integration/sessions_controller_test.rb
@@ -23,7 +23,7 @@ class SessionsControllerTest < ActionDispatch::IntegrationTest
 
   test "returns to the page that sent you to the login" do
     on_subdomain "ams"
-    get upright.prometheus_path
+    get upright.prometheus_path, headers: { "Sec-Fetch-Site" => "same-origin" }
 
     sign_in
 

--- a/test/jobs/upright/playwright_video_sweep_job_test.rb
+++ b/test/jobs/upright/playwright_video_sweep_job_test.rb
@@ -1,0 +1,41 @@
+require "test_helper"
+
+class Upright::PlaywrightVideoSweepJobTest < ActiveSupport::TestCase
+  setup do
+    @video_dir = Pathname.new(Dir.mktmpdir)
+    Upright.configuration.stubs(:video_storage_dir).returns(@video_dir)
+  end
+
+  teardown do
+    FileUtils.remove_entry(@video_dir)
+  end
+
+  test "deletes stray video files older than the sweep age" do
+    stray = @video_dir.join("page@abc123.webm")
+    File.binwrite(stray, "stale video")
+    File.utime(2.hours.ago.to_time, 2.hours.ago.to_time, stray)
+
+    Upright::PlaywrightVideoSweepJob.perform_now
+
+    assert_not File.exist?(stray)
+  end
+
+  test "keeps recent video files" do
+    fresh = @video_dir.join("page@def456.webm")
+    File.binwrite(fresh, "in-flight video")
+
+    Upright::PlaywrightVideoSweepJob.perform_now
+
+    assert File.exist?(fresh)
+  end
+
+  test "ignores non-video files" do
+    other = @video_dir.join("notes.txt")
+    File.binwrite(other, "keep me")
+    File.utime(2.hours.ago.to_time, 2.hours.ago.to_time, other)
+
+    Upright::PlaywrightVideoSweepJob.perform_now
+
+    assert File.exist?(other)
+  end
+end

--- a/test/lib/helpers/authentication_helper.rb
+++ b/test/lib/helpers/authentication_helper.rb
@@ -10,7 +10,9 @@ module AuthenticationHelper
     })
 
     on_subdomain :app
-    get upright.auth_callback_url(provider)
+    # Mirror the real sign-in form, which posts to the callback (see
+    # sessions#create's require_post_for_credential_callback guard).
+    post upright.auth_callback_url(provider)
   end
 
   def sign_out

--- a/test/models/upright/http/request_test.rb
+++ b/test/models/upright/http/request_test.rb
@@ -1,0 +1,74 @@
+require "test_helper"
+
+class Upright::HTTP::RequestTest < ActiveSupport::TestCase
+  setup do
+    set_test_site
+  end
+
+  test "redacts credentials from the verbose log" do
+    stub_typhoeus_response debug_info: stub(
+      text: [ "Connected to example.com\n" ],
+      header_out: [ "GET / HTTP/1.1\r\nHost: example.com\r\nAuthorization: Basic dXNlcjpwYXNz\r\nProxy-Authorization: Basic cHJveHlzZWNyZXQ=\r\nCookie: session=topsecret\r\nAccept: */*\r\n\r\n" ],
+      header_in: [ "HTTP/1.1 200 OK\r\n", "Set-Cookie: session=newsecret; HttpOnly\r\n", "Content-Type: text/html\r\n" ]
+    )
+
+    log = Upright::HTTP::Request.new("https://example.com/", username: "user", password: "pass").get.verbose_log_content
+
+    assert_no_match(/dXNlcjpwYXNz/, log)
+    assert_no_match(/cHJveHlzZWNyZXQ=/, log)
+    assert_no_match(/topsecret/, log)
+    assert_no_match(/newsecret/, log)
+    assert_match(/Authorization:\s*\[REDACTED\]/, log)
+    assert_match(/Proxy-Authorization:\s*\[REDACTED\]/, log)
+    assert_match(/Cookie:\s*\[REDACTED\]/, log)
+    assert_match(/Set-Cookie:\s*\[REDACTED\]/, log)
+  end
+
+  test "redacts sensitive headers case-insensitively and with leading whitespace" do
+    stub_typhoeus_response debug_info: stub(
+      text: [],
+      header_out: [ "  authorization: Bearer sekrit-token\r\nCOOKIE: session=hushhush\r\n" ],
+      header_in: [ "set-cookie: _app=covert\r\n" ]
+    )
+
+    log = Upright::HTTP::Request.new("https://example.com/").get.verbose_log_content
+
+    assert_no_match(/sekrit-token/, log)
+    assert_no_match(/hushhush/, log)
+    assert_no_match(/covert/, log)
+  end
+
+  test "redacts userpwd credential lines" do
+    stub_typhoeus_response debug_info: stub(
+      text: [ "userpwd: user:hunter2\n" ],
+      header_out: [],
+      header_in: []
+    )
+
+    log = Upright::HTTP::Request.new("https://example.com/").get.verbose_log_content
+
+    assert_no_match(/hunter2/, log)
+  end
+
+  test "leaves ordinary headers intact" do
+    stub_typhoeus_response debug_info: stub(
+      text: [ "Connected to example.com\n" ],
+      header_out: [ "GET / HTTP/1.1\r\nHost: example.com\r\nAccept: */*\r\n\r\n" ],
+      header_in: [ "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\n" ]
+    )
+
+    log = Upright::HTTP::Request.new("https://example.com/").get.verbose_log_content
+
+    assert_match(/Host: example.com/, log)
+    assert_match(/Content-Type: text\/html/, log)
+    assert_match(/Connected to example.com/, log)
+  end
+
+  private
+    def stub_typhoeus_response(debug_info:)
+      Typhoeus::Response.new(code: 200).tap do |response|
+        response.stubs(:debug_info).returns(debug_info)
+        Typhoeus.stubs(:get).returns(response)
+      end
+    end
+end

--- a/test/models/upright/playwright/trace_recording_test.rb
+++ b/test/models/upright/playwright/trace_recording_test.rb
@@ -1,0 +1,21 @@
+require "test_helper"
+
+class Upright::Playwright::TraceRecordingTest < ActiveSupport::TestCase
+  class TraceHost
+    include ActiveSupport::Callbacks
+    define_callbacks :page_ready, :page_close
+    include Upright::Playwright::TraceRecording
+
+    attr_accessor :context
+  end
+
+  test "starts tracing without DOM snapshots" do
+    tracing = mock("tracing")
+    tracing.expects(:start).with(screenshots: true, snapshots: false)
+
+    host = TraceHost.new
+    host.context = stub(tracing: tracing)
+
+    host.send(:start_trace)
+  end
+end

--- a/test/models/upright/playwright/trace_recording_test.rb
+++ b/test/models/upright/playwright/trace_recording_test.rb
@@ -4,16 +4,28 @@ class Upright::Playwright::TraceRecordingTest < ActiveSupport::TestCase
   class TraceHost
     include ActiveSupport::Callbacks
     define_callbacks :page_ready, :page_close
+    include Upright::Playwright::FormAuthentication
     include Upright::Playwright::TraceRecording
 
     attr_accessor :context
   end
 
-  test "starts tracing without DOM snapshots" do
+  test "starts a screenshots-only trace for an unauthenticated probe" do
     tracing = mock("tracing")
     tracing.expects(:start).with(screenshots: true, snapshots: false)
 
     host = TraceHost.new
+    host.context = stub(tracing: tracing)
+
+    host.send(:start_trace)
+  end
+
+  test "does not trace an authenticated probe (its network data carries credentials)" do
+    tracing = mock("tracing")
+    tracing.expects(:start).never
+
+    host = TraceHost.new
+    host.authentication_service = :example
     host.context = stub(tracing: tracing)
 
     host.send(:start_trace)

--- a/test/models/upright/playwright/video_recording_test.rb
+++ b/test/models/upright/playwright/video_recording_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+
+class Upright::Playwright::VideoRecordingTest < ActiveSupport::TestCase
+  class VideoHost
+    include ActiveSupport::Callbacks
+    define_callbacks :page_ready, :page_close
+    include Upright::Playwright::VideoRecording
+
+    attr_accessor :logger
+
+    def probe_name = "video_test"
+  end
+
+  setup do
+    set_test_site
+  end
+
+  test "deletes the source video after saving it" do
+    video = mock("video")
+    video.expects(:save_as).with(regexp_matches(/\.webm\z/))
+    video.expects(:delete)
+
+    host = VideoHost.new
+    host.pending_video_recording = { label: nil, video: video }
+
+    host.send(:save_video)
+
+    assert_nil host.pending_video_recording
+    assert_equal 1, host.video_artifacts.size
+  end
+
+  test "deletes the source video even when saving fails" do
+    video = mock("video")
+    video.expects(:save_as).raises(RuntimeError, "context closed")
+    video.expects(:delete)
+
+    host = VideoHost.new
+    host.pending_video_recording = { label: nil, video: video }
+
+    assert_raises(RuntimeError) { host.send(:save_video) }
+    assert_nil host.pending_video_recording
+  end
+
+  test "logs the blob key, never a signed URL" do
+    probe_result = Upright::ProbeResult.create!(probe_type: "playwright", probe_name: "video_test", duration: 1.0, status: "ok")
+    video_path = File.join(Dir.mktmpdir, "#{SecureRandom.hex}.webm")
+    File.binwrite(video_path, "fake video bytes")
+
+    struct_logs = []
+    host = VideoHost.new
+    host.video_artifacts = [ { label: nil, path: video_path } ]
+    host.logger = Logger.new("/dev/null").tap do |logger|
+      logger.define_singleton_method(:struct) { |fields| struct_logs << fields }
+    end
+
+    host.send(:attach_video, probe_result)
+
+    assert struct_logs.any?, "Expected a structured log entry for the video artifact"
+    logged = struct_logs.flat_map { |fields| fields.values.map(&:to_s) }.join(" ")
+    assert_no_match(/rails\/active_storage|https?:/, logged)
+  end
+end

--- a/test/models/upright/probes/http_probe_test.rb
+++ b/test/models/upright/probes/http_probe_test.rb
@@ -168,6 +168,49 @@ class Upright::Probes::HTTPProbeTest < ActiveSupport::TestCase
     assert_equal '{"status": "ok"}', response_artifact.download
   end
 
+  test "stores HTML response bodies as plain text, never text/html" do
+    stub_request(:get, "https://example.com/").to_return(
+      status: 200,
+      body: "<html><script>alert(1)</script></html>",
+      headers: { "Content-Type" => "text/html" }
+    )
+    set_test_site
+    probe = Upright::Probes::HTTPProbe.new(name: "test", url: "https://example.com/")
+    probe.logger = null_logger
+
+    probe.check_and_record
+
+    result = Upright::ProbeResult.last
+    response_artifact = result.artifacts.find { |a| a.filename.to_s.start_with?("response") }
+
+    assert_not_nil response_artifact
+    assert_equal "response.txt", response_artifact.filename.to_s
+    assert_equal "text/plain", response_artifact.content_type
+  end
+
+  test "truncates oversized response bodies" do
+    body = "a" * (Upright::Probes::HTTPProbe::MAX_STORED_BODY_BYTES + 1024)
+    stub_request(:get, "https://example.com/").to_return(
+      status: 200,
+      body: body,
+      headers: { "Content-Type" => "text/plain" }
+    )
+    set_test_site
+    probe = Upright::Probes::HTTPProbe.new(name: "test", url: "https://example.com/")
+    probe.logger = null_logger
+
+    probe.check_and_record
+
+    result = Upright::ProbeResult.last
+    assert_equal "ok", result.status, "truncation must not affect probe success"
+
+    response_artifact = result.artifacts.find { |a| a.filename.to_s.start_with?("response") }
+    stored = response_artifact.download
+
+    assert_operator stored.bytesize, :<=, Upright::Probes::HTTPProbe::MAX_STORED_BODY_BYTES + 100
+    assert_match(/\[TRUNCATED/, stored)
+  end
+
   private
     def null_logger
       Logger.new("/dev/null").tap do |l|

--- a/test/models/upright/service_live_status_test.rb
+++ b/test/models/upright/service_live_status_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+class Upright::ServiceLiveStatusTest < ActiveSupport::TestCase
+  setup do
+    @original_cache = Rails.cache
+    Rails.cache = ActiveSupport::Cache::MemoryStore.new
+  end
+
+  teardown do
+    Rails.cache = @original_cache
+  end
+
+  test "live_status reuses a cached Prometheus reading within the public cache window" do
+    client = mock("prometheus")
+    client.expects(:query).once.returns({ "result" => [ { "value" => [ 1765000000, "1" ] } ] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    service = Upright::Service.find_by(code: "example_app")
+
+    assert_equal :major_outage, service.live_status
+    assert_equal :major_outage, service.live_status
+  end
+
+  test "live_status is cached per service" do
+    client = mock("prometheus")
+    client.expects(:query).twice.returns({ "result" => [ { "value" => [ 1765000000, "0" ] } ] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    assert_equal :operational, Upright::Service.find_by(code: "example_app").live_status
+    assert_equal :operational, Upright::Service.find_by(code: "internal_tools").live_status
+  end
+
+  test "current_outage_started_at reuses a cached Prometheus range within the public cache window" do
+    client = mock("prometheus")
+    client.expects(:query_range).once.returns({ "result" => [ { "values" => [ [ 1765000000, "0" ], [ 1765000300, "1" ] ] } ] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    service = Upright::Service.find_by(code: "example_app")
+
+    assert_equal Time.zone.at(1765000300), service.current_outage_started_at
+    assert_equal Time.zone.at(1765000300), service.current_outage_started_at
+  end
+end

--- a/test/models/upright/traceroute/ip_metadata_lookup_test.rb
+++ b/test/models/upright/traceroute/ip_metadata_lookup_test.rb
@@ -109,6 +109,17 @@ class Upright::Traceroute::IpMetadataLookupTest < ActiveSupport::TestCase
     assert_requested stub, times: 1
   end
 
+  test "uses the TLS pro endpoint when an API key is configured" do
+    Upright::Traceroute::IpMetadataLookup.stubs(:api_key).returns("test-key")
+    stub = stub_request(:post, "https://pro.ip-api.com/batch?key=test-key")
+      .to_return(status: 200, body: [ { "query" => "8.8.8.8", "status" => "success", "as" => "AS15169" } ].to_json)
+
+    results = Upright::Traceroute::IpMetadataLookup.for_many([ "8.8.8.8" ])
+
+    assert_equal "AS15169", results["8.8.8.8"][:as]
+    assert_requested stub, times: 1
+  end
+
   test "handles missing as field" do
     stub_ip_api_request(response: [ { "query" => "8.8.8.8", "status" => "success", "isp" => "Google LLC" } ])
 

--- a/test/models/upright/traceroute/result_test.rb
+++ b/test/models/upright/traceroute/result_test.rb
@@ -24,7 +24,7 @@ class Upright::Traceroute::ResultTest < ActiveSupport::TestCase
   end
 
   test "accepts hostnames and IP addresses" do
-    [ "example.com", "sub-domain.example.com", "8.8.8.8", "2001:4860:4860::8888", "::1" ].each do |host|
+    [ "example.com", "sub-domain.example.com", "8.8.8.8", "2001:4860:4860::8888", "::1", "fe80::1%eth0" ].each do |host|
       assert Upright::Traceroute::Result.new(host), "expected #{host.inspect} to be accepted"
     end
   end

--- a/test/models/upright/traceroute/result_test.rb
+++ b/test/models/upright/traceroute/result_test.rb
@@ -22,4 +22,18 @@ class Upright::Traceroute::ResultTest < ActiveSupport::TestCase
 
     assert_not @result.reached_destination?
   end
+
+  test "accepts hostnames and IP addresses" do
+    [ "example.com", "sub-domain.example.com", "8.8.8.8", "2001:4860:4860::8888", "::1" ].each do |host|
+      assert Upright::Traceroute::Result.new(host), "expected #{host.inspect} to be accepted"
+    end
+  end
+
+  test "rejects hosts that could be treated as mtr flags or shell input" do
+    [ "-c", "--raw", "-inet", "example.com --raw", "host;id", "$(id)", "", nil ].each do |host|
+      assert_raises ArgumentError, "expected #{host.inspect} to be rejected" do
+        Upright::Traceroute::Result.new(host)
+      end
+    end
+  end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -41,6 +41,16 @@ module ActiveSupport
       original_values.each { |k, v| ENV[k] = v }
     end
 
+    # The test environment turns forgery protection off, so anything asserting how
+    # a controller verifies a request has to switch it back on for the duration.
+    def with_forgery_protection
+      original = ActionController::Base.allow_forgery_protection
+      ActionController::Base.allow_forgery_protection = true
+      yield
+    ensure
+      ActionController::Base.allow_forgery_protection = original
+    end
+
     def stub_ip_api_batch(response_body = "[]")
       stub_request(:post, "http://ip-api.com/batch").to_return(status: 200, body: response_body)
     end

--- a/upright.gemspec
+++ b/upright.gemspec
@@ -36,6 +36,11 @@ Gem::Specification.new do |spec|
   spec.add_dependency "frozen_record"
   spec.add_dependency "typhoeus"
 
+  # HTTP client for the metrics proxies. Floor at 2.14.3: earlier releases let a
+  # protocol-relative path (`//host`) override the upstream authority via
+  # URI#merge, an SSRF through the proxies (CVE-2026-25765 / -33637 / -54297).
+  spec.add_dependency "faraday", ">= 2.14.3"
+
   # Playwright (browser automation)
   # Keep in sync with Upright::PLAYWRIGHT_VERSION in lib/upright/version.rb
   spec.add_dependency "playwright-ruby-client", "~> 1.59.0"


### PR DESCRIPTION
Comprehensive security pass responding to two reported CVEs and an internal adversarial audit. All fixes ship as separate, reviewable commits; every fix landed its regression test first.

## Reported (BUPT researchers)
- **CVE-2026-67993** — login CSRF on the `static_credentials` callback: now requires a POST with a valid authenticity token, GET/HEAD refused, and the install template fails closed when `ADMIN_PASSWORD` is unset. (GHSA-28vc-xxc6-jprh, Low)
- **CVE-2026-67990** — proxy CSRF: a Fetch-Metadata/Origin gate on the session-cookie path (same-origin only; same-site sub-resources and writes refused; missing headers fail closed). (GHSA-q3r2-rf24-9rj7, Low)

## Found in audit
- **F-01 SSRF (High, CVE-2026-25765):** the proxies passed `request.fullpath` to Faraday, whose `URI#merge` let `//host` override the upstream authority (RFC1918 / Docker / cloud metadata). Path is now validated, the resolved host re-checked, destructive endpoints denied on the token path, and `faraday >= 2.14.3` pinned in the gemspec.
- Session cookie scoped to `.#{hostname}` instead of the registrable parent (F-08); `httponly` explicit; `return_to` host-allowlisted (F-15).
- Probe artifacts: redact `Authorization`/`Cookie` from logs, store HTTP bodies as inert size-capped files, drop Playwright snapshots and signed-blob-URL logging, sweep stray videos, scope artifact downloads to probe results (F-04/05/18/13/19).
- Public status scoped to public-facing incidents + live-status caching (F-06/17).
- Deploy defaults: no Docker socket in the OTEL accessory, loopback binds, random proxy token, CSP template, fail-closed password docs; boot refuses a blank proxy token outside local (F-09/10/12/21/22).
- Small leftovers: `mtr`/`ping` argv `--` guard, ip-api TLS, sites-map XSS escape (F-23/24/25).

## Notes
- Trace-viewer isolation (F-03) is intentionally **not** in this PR: the secure in-process sandbox renders the viewer inert, so it's deferred to a follow-up that moves the viewer off the admin origin.
- Follows PR #118 (Active Storage RCE) and #125 (faraday/addressable).
- A minimal **0.3.1** backport of the applicable fixes will follow for existing gem users.

Full suite green locally (excluding browser/mtr-dependent probe tests); rubocop + Brakeman clean.