### PR TITLE
Delete the Playwright source video once it's been copied

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## Unreleased
 
+- Delete the Playwright source video once it's been copied, so `record_video_dir` stops growing without bound (#128)
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)
 - Add incidents and scheduled maintenance, with a public timeline and impact banner (#102)

--- a/app/models/concerns/upright/playwright/video_recording.rb
+++ b/app/models/concerns/upright/playwright/video_recording.rb
@@ -42,12 +42,14 @@ module Upright::Playwright::VideoRecording
     def save_video
       return unless pending_video_recording
 
+      video = pending_video_recording.fetch(:video)
       video_path = video_dir.join("#{SecureRandom.hex}.webm").to_s
-      pending_video_recording.fetch(:video).save_as(video_path)
+      video.save_as(video_path)
 
       self.video_artifacts ||= []
       video_artifacts << pending_video_recording.merge(path: video_path)
     ensure
+      video&.delete rescue Rails.error.report($!)
       self.pending_video_recording = nil
     end
 

--- a/test/models/upright/playwright/video_recording_test.rb
+++ b/test/models/upright/playwright/video_recording_test.rb
@@ -1,0 +1,57 @@
+require "test_helper"
+
+class Upright::Playwright::VideoRecordingTest < ActiveSupport::TestCase
+  class FakeVideo
+    attr_reader :source_path
+
+    def initialize(source_path)
+      @source_path = source_path
+      File.write(source_path, "video")
+    end
+
+    def save_as(path) = FileUtils.cp(source_path, path)
+    def delete = FileUtils.rm_f(source_path)
+  end
+
+  class TestProbe < Upright::Probes::Playwright::Base
+    def check = true
+  end
+
+  setup do
+    @video_dir = Pathname.new(Dir.mktmpdir)
+    Upright.configuration.video_storage_dir = @video_dir
+
+    @video = FakeVideo.new(@video_dir.join("page@abc123.webm").to_s)
+    @probe = TestProbe.new
+    @probe.pending_video_recording = { label: nil, video: @video }
+  end
+
+  teardown do
+    Upright.configuration.video_storage_dir = nil
+    FileUtils.remove_entry(@video_dir)
+  end
+
+  test "deletes the Playwright source video once the copy is saved" do
+    @probe.send(:save_video)
+
+    assert_not File.exist?(@video.source_path)
+    assert File.exist?(@probe.video_artifacts.first.fetch(:path))
+  end
+
+  test "deletes the Playwright source video when saving the copy raises" do
+    @video.stubs(:save_as).raises(RuntimeError, "stream closed")
+
+    assert_raises(RuntimeError) { @probe.send(:save_video) }
+
+    assert_not File.exist?(@video.source_path)
+  end
+
+  test "reports a failed delete instead of raising" do
+    @video.stubs(:delete).raises(RuntimeError, "channel closed")
+    Rails.error.expects(:report).once
+
+    @probe.send(:save_video)
+
+    assert_equal 1, @probe.video_artifacts.size
+  end
+end


### PR DESCRIPTION
Fixes #110.

Chromium writes its own recording into `record_video_dir`, which `video_recording_options` points at `video_storage_dir`. `save_video` then streams a second copy into that same directory via `Video#save_as`, and `attach_video` uploads that copy and removes it. Nothing ever removed Playwright's original, so every check leaked one `page@<hash>.webm`, forever. The reporter saw `storage/playwright_videos` reach 36 GB at roughly 0.4 GB/day.

`Video#save_as` only copies the artifact, it goes through `saveAsStream` and leaves the source in place. `Video#delete` is what removes it, and Upright never called it.

## The change

Hoist the video to a local and call `video&.delete` in the existing `ensure`:

```ruby
def save_video
  return unless pending_video_recording

  video = pending_video_recording.fetch(:video)
  video_path = video_dir.join("#{SecureRandom.hex}.webm").to_s
  video.save_as(video_path)

  self.video_artifacts ||= []
  video_artifacts << pending_video_recording.merge(path: video_path)
ensure
  video&.delete rescue Rails.error.report($!)
  self.pending_video_recording = nil
end
```

Deleting in `ensure` is the point: if `save_as` raises, the source would otherwise be leaked permanently.

The rescue is load-bearing rather than merely defensive. `Video#delete` can itself raise, since `@artifact.value!` re-raises when the page closed without producing frames and the channel may already be gone. Without the rescue, a failure there in `ensure` would replace whatever `save_as` raised and hide the original error. The form matches the existing `page&.close rescue Rails.error.report($!)` in `Upright::Playwright::Lifecycle`.

## Scope

This fixes the primary leak, the Playwright source, which leaks once per check unconditionally.

It does not address the secondary case the issue mentions, the `<hex>.webm` copy stranded when attaching never completes. `attach_video` only removes files it successfully attaches, so a failure before or during attach still leaves that copy behind. That is a different code path and a different failure mode, so I left it out to keep this diff focused. Happy to follow up if you'd like it in the same PR.

The issue also suggests writing the `save_as` copy to a tmp dir rather than into `record_video_dir`. That is a reasonable cleanup but a separate change, so it's not included here.

## Tests

Added `test/models/upright/playwright/video_recording_test.rb`. A `FakeVideo` mirrors the real semantics, the constructor writes the source file, `save_as` copies it, and `delete` removes the source, with the video dir pointed at a `Dir.mktmpdir`. Three cases:

1. happy path, the source is gone and the copy is recorded in `video_artifacts`
2. `save_as` raises, the source is still cleaned up
3. `delete` raises, the error is reported and `save_video` does not raise

All three were written first and fail against unmodified code.

## Verification

- `bin/rubocop`: 188 files, no offenses.
- The three new tests pass, and all three fail with the source change reverted.
- Full `bin/rails test`: 5 pre-existing environmental failures on my machine, 3 in `playwright_probe_test.rb` because Chromium isn't installed locally and 2 in `traceroute_probe_test.rb` because `mtr-packet` can't open raw sockets unprivileged on macOS. Both files fail identically on unmodified `main`.

I could not verify the real `Video#delete` round-trip against a live Playwright server locally, for the Chromium reason above. The unit tests cover the logic. The issue reporter states they ran this patch in production and confirmed `record_video_dir` stays empty between checks.
