### PR TITLE
0.3.1 security backport: proxy SSRF + CSRF, login CSRF, session cookie

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,26 @@
 # Changelog
 
+## v0.3.1
+
+Security backport release for v0.3.0 installs.
+
+### Security
+
+- Fix an authenticated SSRF through the Prometheus/Alertmanager proxies: a
+  protocol-relative path (`//host`) could retarget the upstream request at an
+  arbitrary host (RFC1918, the Docker network, cloud metadata). Forwarded paths
+  are now validated and the resolved host is re-checked, with a `faraday >= 2.14.3`
+  floor (CVE-2026-25765).
+- Refuse cross-site requests to the metrics proxies on the session-cookie path
+  via a Fetch-Metadata / Origin gate; only same-origin, user-initiated, and
+  same-site top-level navigations are honoured (CVE-2026-67990).
+- Require a POST with a valid authenticity token on the `static_credentials`
+  sign-in callback, and fail closed when `ADMIN_PASSWORD` is unset instead of
+  shipping a default password (CVE-2026-67993).
+- Scope the session cookie to the configured hostname rather than its registrable
+  parent, so a sibling domain can't be handed the admin session, and mark it
+  httponly (F-08).
+
 ## v0.3.0
 
 - Allow host apps to register custom probe types via `config.probe_types.register` (#42)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,14 +12,24 @@ Security backport release for v0.3.0 installs.
   are now validated and the resolved host is re-checked, with a `faraday >= 2.14.3`
   floor (CVE-2026-25765).
 - Refuse cross-site requests to the metrics proxies on the session-cookie path
-  via a Fetch-Metadata / Origin gate; only same-origin, user-initiated, and
-  same-site top-level navigations are honoured (CVE-2026-67990).
+  via a Fetch-Metadata / Origin gate; only same-origin and user-initiated (`none`)
+  requests are honoured, and missing provenance headers fail closed
+  (CVE-2026-67990).
 - Require a POST with a valid authenticity token on the `static_credentials`
   sign-in callback, and fail closed when `ADMIN_PASSWORD` is unset instead of
   shipping a default password (CVE-2026-67993).
 - Scope the session cookie to the configured hostname rather than its registrable
   parent, so a sibling domain can't be handed the admin session, and mark it
   httponly (F-08).
+
+### Upgrading
+
+The `static_credentials` fail-closed password fix lives in the install template,
+which a gem upgrade does not copy back over an existing app. Existing v0.3.0
+installs must update `config/initializers/omniauth.rb` by hand so an unset
+`ADMIN_PASSWORD` no longer falls back to the well-known `upright` default — set
+`ADMIN_PASSWORD`, or mirror the current template (which drops the default). The
+SSRF and proxy/login CSRF fixes are in engine code and apply automatically.
 
 ## v0.3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,10 @@ Security backport release for v0.3.0 installs.
 
 ### Upgrading
 
+Everyone signs in again once: the session cookie key changed so a 0.3.0 cookie
+scoped to the registrable parent can't linger usable after the scope tightened
+(F-08).
+
 The `static_credentials` fail-closed password fix lives in the install template,
 which a gem upgrade does not copy back over an existing app. Existing v0.3.0
 installs must update `config/initializers/omniauth.rb` by hand so an unset

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,6 +3,7 @@ PATH
   specs:
     upright (0.2.0)
       cgi
+      faraday (>= 2.14.3)
       frozen_record
       geared_pagination
       importmap-rails
@@ -136,7 +137,7 @@ GEM
     ethon (0.18.0)
       ffi (>= 1.15.0)
       logger
-    faraday (2.14.0)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
@@ -666,7 +667,7 @@ CHECKSUMS
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
   et-orbi (1.4.0) sha256=6c7e3c90779821f9e3b324c5e96fda9767f72995d6ae435b96678a4f3e2de8bc
   ethon (0.18.0) sha256=b598afc9f30448cb068b850714b7d6948e941476095d04f90a4ac65b8d6efcb2
-  faraday (2.14.0) sha256=8699cfe5d97e55268f2596f9a9d5a43736808a943714e3d9a53e6110593941cd
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-follow_redirects (0.5.0) sha256=5cde93c894b30943a5d2b93c2fe9284216a6b756f7af406a1e55f211d97d10ad
   faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
   ffi (1.17.3-arm64-darwin) sha256=0c690555d4cee17a7f07c04d59df39b2fba74ec440b19da1f685c6579bb0717f

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upright (0.2.0)
+    upright (0.3.1)
       cgi
       faraday (>= 2.14.3)
       frozen_record
@@ -819,7 +819,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  upright (0.2.0)
+  upright (0.3.1)
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451

--- a/README.md
+++ b/README.md
@@ -136,10 +136,13 @@ Each site node identifies itself via the `SITE_SUBDOMAIN` environment variable, 
 
 #### Static Credentials
 
-Upright uses static credentials by default with username `admin` and password `upright`.
+Upright uses static credentials with username `admin`. There is no default
+password: set the `ADMIN_PASSWORD` environment variable to a strong value.
 
 > [!WARNING]
-> Change the default password before deploying to production by setting the `ADMIN_PASSWORD` environment variable.
+> Sign-in fails closed when `ADMIN_PASSWORD` is unset — the admin login is
+> disabled until you set it. For local development you can export a throwaway
+> value, e.g. `ADMIN_PASSWORD=upright bin/dev`.
 
 
 #### OpenID Connect

--- a/app/controllers/concerns/upright/proxy_guards.rb
+++ b/app/controllers/concerns/upright/proxy_guards.rb
@@ -5,7 +5,7 @@ module Upright::ProxyGuards
   # nothing outside the RFC 3986 path character set. This is what stops a request
   # like `/prometheus//169.254.169.254/…` from retargeting Faraday at another host
   # (SSRF, CVE-2026-25765).
-  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~%!$&'()*+,;=:@/]*\z}
+  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~!$&'()*+,;=:@/]*\z}
   MAX_UPSTREAM_QUERY = 4096
 
   included do
@@ -36,9 +36,11 @@ module Upright::ProxyGuards
       elsif origin.present?
         origin != request.base_url
       else
-        # No Fetch-Metadata and no Origin (a pre-Fetch-Metadata browser): fail
-        # closed on state-changing methods, allow plain reads.
-        !request.get? && !request.head?
+        # No Fetch-Metadata and no Origin: treat as cross-site and refuse. Every
+        # current browser sends Sec-Fetch-Site (and the embedded same-origin UI
+        # does too), so only a pre-2023 client omits it; failing closed keeps a
+        # header-less cross-site GET from riding the Lax session cookie.
+        true
       end
     end
 
@@ -49,7 +51,11 @@ module Upright::ProxyGuards
       path, separator, query = raw.to_s.partition("?")
       path = "/" if path.empty?
 
-      if path.start_with?("//") || path.include?("..") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+      # Also reject any percent-encoding in the path: the proxied UIs only
+      # percent-encode query strings, and a double-encoded separator (%252f → %2f
+      # → /) would otherwise decode on the upstream and slip an authority override
+      # or a denied prefix past these checks.
+      if path.start_with?("//") || path.include?("..") || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
         nil
       else
         "#{path}#{separator}#{query}"

--- a/app/controllers/concerns/upright/proxy_guards.rb
+++ b/app/controllers/concerns/upright/proxy_guards.rb
@@ -1,0 +1,37 @@
+module Upright::ProxyGuards
+  extend ActiveSupport::Concern
+
+  included do
+    prepend_before_action :block_cross_site_session_requests
+  end
+
+  private
+    # CSRF gate for the browser (session-cookie) path. Rails token CSRF is skipped
+    # on the proxies because the embedded Prometheus/Alertmanager UIs make
+    # same-origin requests that can't carry an authenticity token, so we gate with
+    # Fetch-Metadata / Origin instead (CVE-2026-67990). The token-authenticated
+    # OTLP ingest endpoint skips this gate and stays on its own 401 path.
+    def block_cross_site_session_requests
+      head :forbidden if cross_site_request?
+    end
+
+    def cross_site_request?
+      site = request.headers["Sec-Fetch-Site"]
+      origin = request.headers["Origin"]
+
+      if site.present?
+        # Same-origin (the embedded UI) and user-initiated `none` (typed URL /
+        # bookmark) are fine; a same-site *top-level GET navigation* is an admin
+        # moving between our own subdomains. Everything else — cross-site, and any
+        # same-site sub-resource or write — is refused.
+        !(site.in?(%w[ same-origin none ]) ||
+          (site == "same-site" && request.get? && request.headers["Sec-Fetch-Mode"] == "navigate"))
+      elsif origin.present?
+        origin != request.base_url
+      else
+        # No Fetch-Metadata and no Origin (a pre-Fetch-Metadata browser): fail
+        # closed on state-changing methods, allow plain reads.
+        !request.get? && !request.head?
+      end
+    end
+end

--- a/app/controllers/concerns/upright/proxy_guards.rb
+++ b/app/controllers/concerns/upright/proxy_guards.rb
@@ -27,12 +27,12 @@ module Upright::ProxyGuards
       origin = request.headers["Origin"]
 
       if site.present?
-        # Same-origin (the embedded UI) and user-initiated `none` (typed URL /
-        # bookmark) are fine; a same-site *top-level GET navigation* is an admin
-        # moving between our own subdomains. Everything else — cross-site, and any
-        # same-site sub-resource or write — is refused.
-        !(site.in?(%w[ same-origin none ]) ||
-          (site == "same-site" && request.get? && request.headers["Sec-Fetch-Mode"] == "navigate"))
+        # Only same-origin (the embedded UI) and user-initiated `none` (a typed
+        # URL or bookmark) are allowed. same-site is refused too: a sibling on the
+        # same registrable domain (evil.example.com vs ams.upright.example.com) is
+        # same-site, and a top-level navigation from it would otherwise carry the
+        # Lax cookie into a forged proxy request.
+        !site.in?(%w[ same-origin none ])
       elsif origin.present?
         origin != request.base_url
       else
@@ -51,11 +51,11 @@ module Upright::ProxyGuards
       path, separator, query = raw.to_s.partition("?")
       path = "/" if path.empty?
 
-      # Also reject any percent-encoding in the path: the proxied UIs only
-      # percent-encode query strings, and a double-encoded separator (%252f → %2f
-      # → /) would otherwise decode on the upstream and slip an authority override
-      # or a denied prefix past these checks.
-      if path.start_with?("//") || path.include?("..") || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+      # Reject any dot-segment (`.`/`..`) and any percent-encoding in the path.
+      # Faraday resolves the path with URI#merge, which collapses `.`/`..` and
+      # decodes escapes, so `/./-/reload` or `/%252d%252freload` would otherwise
+      # slip an authority override or a denied prefix past these checks.
+      if path.start_with?("//") || path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
         nil
       else
         "#{path}#{separator}#{query}"

--- a/app/controllers/concerns/upright/proxy_guards.rb
+++ b/app/controllers/concerns/upright/proxy_guards.rb
@@ -1,6 +1,13 @@
 module Upright::ProxyGuards
   extend ActiveSupport::Concern
 
+  # A forwarded path may only be a path: no authority (`//host`), no traversal,
+  # nothing outside the RFC 3986 path character set. This is what stops a request
+  # like `/prometheus//169.254.169.254/…` from retargeting Faraday at another host
+  # (SSRF, CVE-2026-25765).
+  SAFE_UPSTREAM_PATH = %r{\A/[A-Za-z0-9\-._~%!$&'()*+,;=:@/]*\z}
+  MAX_UPSTREAM_QUERY = 4096
+
   included do
     prepend_before_action :block_cross_site_session_requests
   end
@@ -33,5 +40,31 @@ module Upright::ProxyGuards
         # closed on state-changing methods, allow plain reads.
         !request.get? && !request.head?
       end
+    end
+
+    # Validate the operator-controlled proxy path before it reaches Faraday, and
+    # cap the query so an operator query can't be turned into a nested-params DoS.
+    # Returns the safe "path[?query]" to forward, or nil to reject.
+    def sanitized_upstream_path(raw)
+      path, separator, query = raw.to_s.partition("?")
+      path = "/" if path.empty?
+
+      if path.start_with?("//") || path.include?("..") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+        nil
+      else
+        "#{path}#{separator}#{query}"
+      end
+    end
+
+    # Belt-and-suspenders after path validation: resolve the forwarded path the
+    # same way Faraday's Connection does (URI#merge) and require that it still
+    # lands on the configured upstream host and port. This catches an authority
+    # override (`//host`) even if the character-level check above ever misses one.
+    def upstream_host_ok?(base_url, forward)
+      base = URI.parse(base_url)
+      built = base.merge(forward)
+      built.host == base.host && built.port == base.port
+    rescue URI::Error
+      false
     end
 end

--- a/app/controllers/concerns/upright/proxy_guards.rb
+++ b/app/controllers/concerns/upright/proxy_guards.rb
@@ -9,15 +9,18 @@ module Upright::ProxyGuards
   MAX_UPSTREAM_QUERY = 4096
 
   included do
-    prepend_before_action :block_cross_site_session_requests
+    # Only the forwarding `proxy` action needs the cross-site gate. `show` just
+    # renders the framed UI wrapper (no upstream call, no state change), so gating
+    # it too would 403 a legitimate same-site navigation to it — e.g. an operator
+    # following the header link from a site subdomain to app.<hostname>.
+    prepend_before_action :block_cross_site_session_requests, only: :proxy
   end
 
   private
     # CSRF gate for the browser (session-cookie) path. Rails token CSRF is skipped
     # on the proxies because the embedded Prometheus/Alertmanager UIs make
     # same-origin requests that can't carry an authenticity token, so we gate with
-    # Fetch-Metadata / Origin instead (CVE-2026-67990). The token-authenticated
-    # OTLP ingest endpoint skips this gate and stays on its own 401 path.
+    # Fetch-Metadata / Origin instead (CVE-2026-67990).
     def block_cross_site_session_requests
       head :forbidden if cross_site_request?
     end
@@ -55,7 +58,9 @@ module Upright::ProxyGuards
       # Faraday resolves the path with URI#merge, which collapses `.`/`..` and
       # decodes escapes, so `/./-/reload` or `/%252d%252freload` would otherwise
       # slip an authority override or a denied prefix past these checks.
-      if path.start_with?("//") || path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
+      # Rack::Utils.valid_path? runs first: it screens null bytes and broken
+      # encoding, which would otherwise raise out of String#match?.
+      if !Rack::Utils.valid_path?(path) || path.start_with?("//") || path.match?(%r{(?:\A|/)\.\.?(?:/|\z)}) || path.include?("%") || !path.match?(SAFE_UPSTREAM_PATH) || query.length > MAX_UPSTREAM_QUERY
         nil
       else
         "#{path}#{separator}#{query}"

--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -7,7 +7,13 @@ class Upright::AlertmanagerProxyController < Upright::ApplicationController
   end
 
   def proxy
-    proxy_to_alertmanager request.fullpath.delete_prefix("/alertmanager"), body: request.body&.read
+    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/alertmanager"))
+
+    if forward.nil? || !upstream_host_ok?(alertmanager_url, forward)
+      head :bad_request
+    else
+      proxy_to_alertmanager forward, body: request.body&.read
+    end
   end
 
   private

--- a/app/controllers/upright/alertmanager_proxy_controller.rb
+++ b/app/controllers/upright/alertmanager_proxy_controller.rb
@@ -1,4 +1,6 @@
 class Upright::AlertmanagerProxyController < Upright::ApplicationController
+  include Upright::ProxyGuards
+
   skip_forgery_protection
 
   def show

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -1,7 +1,10 @@
 class Upright::PrometheusProxyController < Upright::ApplicationController
+  include Upright::ProxyGuards
+
   skip_forgery_protection
 
   skip_before_action :authenticate_user, only: :otlp
+  skip_before_action :block_cross_site_session_requests, only: :otlp
   before_action :authenticate_otlp_token, only: :otlp
 
   UNSUPPORTED_PATHS = %w[/api/v1/notifications]

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -13,12 +13,15 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   end
 
   def proxy
-    path = request.fullpath.sub(%r{^/prometheus}, "")
+    forward = sanitized_upstream_path(request.fullpath.delete_prefix("/prometheus"))
+    path = forward&.split("?", 2)&.first
 
-    if path.start_with?(*UNSUPPORTED_PATHS)
+    if forward.nil? || !upstream_host_ok?(prometheus_url, forward)
+      head :bad_request
+    elsif path.start_with?(*UNSUPPORTED_PATHS)
       head :not_found
     else
-      proxy_to_prometheus(path)
+      proxy_to_prometheus(forward)
     end
   end
 

--- a/app/controllers/upright/prometheus_proxy_controller.rb
+++ b/app/controllers/upright/prometheus_proxy_controller.rb
@@ -4,7 +4,6 @@ class Upright::PrometheusProxyController < Upright::ApplicationController
   skip_forgery_protection
 
   skip_before_action :authenticate_user, only: :otlp
-  skip_before_action :block_cross_site_session_requests, only: :otlp
   before_action :authenticate_otlp_token, only: :otlp
 
   UNSUPPORTED_PATHS = %w[/api/v1/notifications]

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -1,8 +1,8 @@
 class Upright::SessionsController < Upright::ApplicationController
   skip_before_action :authenticate_user, only: [ :new, :create ]
-  skip_forgery_protection only: :create
 
   before_action :ensure_not_signed_in, only: [ :new, :create ]
+  before_action :require_post_for_credential_callback, only: :create
 
   def new
   end
@@ -22,6 +22,18 @@ class Upright::SessionsController < Upright::ApplicationController
   private
     def ensure_not_signed_in
       redirect_to upright.site_root_path if session[:user_info].present?
+    end
+
+    # The credential (static_credentials) callback must arrive as a POST so it
+    # passes through Rails' authenticity-token check: any other verb (a Lax-cookie
+    # GET, or a HEAD that CSRF also skips) could otherwise plant an attacker-chosen
+    # session (CVE-2026-67993). External identity providers (e.g. OpenID Connect)
+    # legitimately redirect back via GET and are validated by OmniAuth's own state
+    # nonce before we reach here, so they are exempt.
+    def require_post_for_credential_callback
+      if !request.post? && params[:provider].to_s == "static_credentials"
+        head :not_found
+      end
     end
 
     def upright

--- a/app/controllers/upright/sessions_controller.rb
+++ b/app/controllers/upright/sessions_controller.rb
@@ -1,8 +1,14 @@
 class Upright::SessionsController < Upright::ApplicationController
   skip_before_action :authenticate_user, only: [ :new, :create ]
+  # External identity providers (OpenID Connect, including
+  # `response_mode=form_post`) return to the callback without a Rails authenticity
+  # token and are validated by the provider's own state nonce, so Rails' automatic
+  # token check is skipped here. The static_credentials callback is same-origin and
+  # MUST present a token — enforced explicitly in verify_credential_callback.
+  skip_forgery_protection only: :create
 
   before_action :ensure_not_signed_in, only: [ :new, :create ]
-  before_action :require_post_for_credential_callback, only: :create
+  before_action :verify_credential_callback, only: :create
 
   def new
   end
@@ -24,15 +30,18 @@ class Upright::SessionsController < Upright::ApplicationController
       redirect_to upright.site_root_path if session[:user_info].present?
     end
 
-    # The credential (static_credentials) callback must arrive as a POST so it
-    # passes through Rails' authenticity-token check: any other verb (a Lax-cookie
-    # GET, or a HEAD that CSRF also skips) could otherwise plant an attacker-chosen
-    # session (CVE-2026-67993). External identity providers (e.g. OpenID Connect)
-    # legitimately redirect back via GET and are validated by OmniAuth's own state
-    # nonce before we reach here, so they are exempt.
-    def require_post_for_credential_callback
-      if !request.post? && params[:provider].to_s == "static_credentials"
+    # The static_credentials callback must arrive as a POST carrying a valid
+    # authenticity token: any other verb (a Lax-cookie GET, or a HEAD that CSRF
+    # skips) or a missing/foreign token could otherwise plant an attacker-chosen
+    # session (CVE-2026-67993). External providers are validated by their own
+    # state nonce (see skip_forgery_protection above) and are exempt.
+    def verify_credential_callback
+      return unless params[:provider].to_s == "static_credentials"
+
+      if !request.post?
         head :not_found
+      elsif !verified_request?
+        raise ActionController::InvalidAuthenticityToken
       end
     end
 

--- a/app/views/upright/sessions/new.html.erb
+++ b/app/views/upright/sessions/new.html.erb
@@ -1,6 +1,19 @@
 <div class="sign-in-container">
   <div class="sign-in-box">
     <h1>Upright</h1>
-    <%= button_to "Sign in", "/auth/#{Upright.configuration.auth_provider}", method: :post, data: { turbo: false }, class: "btn" %>
+    <% if Upright.configuration.auth_provider.to_sym == :static_credentials %>
+      <%# Post credentials straight to the OmniAuth callback, but as a same-origin
+          form carrying a Rails authenticity token so a cross-site request can't
+          forge a sign-in (CVE-2026-67993). %>
+      <%= form_with url: "/auth/static_credentials/callback", method: :post, data: { turbo: false } do |form| %>
+        <%= form.label :username, "Username" %>
+        <%= form.text_field :username, autocomplete: "username" %>
+        <%= form.label :password, "Password" %>
+        <%= form.password_field :password, autocomplete: "current-password" %>
+        <%= form.submit "Sign in", class: "btn" %>
+      <% end %>
+    <% else %>
+      <%= button_to "Sign in", "/auth/#{Upright.configuration.auth_provider}", method: :post, data: { turbo: false }, class: "btn" %>
+    <% end %>
   </div>
 </div>

--- a/lib/generators/upright/install/templates/omniauth.rb
+++ b/lib/generators/upright/install/templates/omniauth.rb
@@ -1,8 +1,12 @@
-# WARNING: Change the default password before deploying to production!
-# Set the ADMIN_PASSWORD environment variable or update the credentials below.
+# Set ADMIN_PASSWORD to enable the built-in admin login. When it is unset the
+# static credential is left unconfigured (fail closed) so the app never ships a
+# well-known default password. Change the username/credentials below to suit, or
+# switch to an external provider (e.g. OpenID Connect) via config.auth_provider.
+
+admin_password = ENV["ADMIN_PASSWORD"].presence
 
 Rails.application.config.middleware.use OmniAuth::Builder do
   provider :static_credentials,
     title: "Sign In",
-    credentials: { "admin" => ENV.fetch("ADMIN_PASSWORD", "upright") }
+    credentials: admin_password ? { "admin" => admin_password } : {}
 end

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -115,6 +115,11 @@ class Upright::Configuration
     def configure_allowed_hosts
       port_suffix = Rails.env.local? ? "(:\\d+)?" : ""
       Rails.application.config.hosts = [ /.*\.#{Regexp.escape(hostname)}#{port_suffix}/, /#{Regexp.escape(hostname)}#{port_suffix}/ ]
-      Rails.application.config.action_dispatch.tld_length = 1
+      # Derive tld_length from the configured hostname's depth rather than forcing
+      # 1. This keeps subdomain parsing correct for multi-label hostnames and, for
+      # `domain: :all` session cookies, scopes the cookie to `.#{hostname}` instead
+      # of the registrable parent — so a sibling like evil.example.com can't be
+      # handed the admin session when the app runs at upright.example.com (F-08).
+      Rails.application.config.action_dispatch.tld_length = hostname.count(".")
     end
 end

--- a/lib/upright/configuration.rb
+++ b/lib/upright/configuration.rb
@@ -115,11 +115,6 @@ class Upright::Configuration
     def configure_allowed_hosts
       port_suffix = Rails.env.local? ? "(:\\d+)?" : ""
       Rails.application.config.hosts = [ /.*\.#{Regexp.escape(hostname)}#{port_suffix}/, /#{Regexp.escape(hostname)}#{port_suffix}/ ]
-      # Derive tld_length from the configured hostname's depth rather than forcing
-      # 1. This keeps subdomain parsing correct for multi-label hostnames and, for
-      # `domain: :all` session cookies, scopes the cookie to `.#{hostname}` instead
-      # of the registrable parent — so a sibling like evil.example.com can't be
-      # handed the admin session when the app runs at upright.example.com (F-08).
-      Rails.application.config.action_dispatch.tld_length = hostname.count(".")
+      Rails.application.config.action_dispatch.tld_length = 1
     end
 end

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -6,9 +6,14 @@ class Upright::Engine < ::Rails::Engine
 
   # Session store configuration
   initializer "upright.session_store", before: :load_config_initializers do |app|
+    # Scope the cookie to the configured hostname (resolved per-request, since the
+    # host app sets it in an initializer that runs after this one) rather than
+    # `domain: :all`, which — with a multi-label hostname like upright.example.com
+    # — would hand the cookie to the registrable parent and every sibling under it
+    # (F-08).
     app.config.session_store :cookie_store,
       key: "_upright_session",
-      domain: :all,
+      domain: ->(_request) { Upright.configuration.hostname&.then { |h| ".#{h}" } },
       same_site: :lax,
       secure: Rails.env.production?,
       httponly: true,

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -12,7 +12,11 @@ class Upright::Engine < ::Rails::Engine
     # — would hand the cookie to the registrable parent and every sibling under it
     # (F-08).
     app.config.session_store :cookie_store,
-      key: "_upright_session",
+      # Bumped from "_upright_session" so upgrading from 0.3.0 (which scoped the
+      # cookie to the registrable parent via domain: :all) doesn't leave that old,
+      # broadly-scoped cookie usable: the new key ignores it, and it ages out at
+      # its original expiry. Costs a one-time re-login on upgrade (F-08).
+      key: "_upright_session_v2",
       domain: ->(_request) { Upright.configuration.hostname&.then { |h| ".#{h}" } },
       same_site: :lax,
       secure: Rails.env.production?,

--- a/lib/upright/engine.rb
+++ b/lib/upright/engine.rb
@@ -11,6 +11,7 @@ class Upright::Engine < ::Rails::Engine
       domain: :all,
       same_site: :lax,
       secure: Rails.env.production?,
+      httponly: true,
       expire_after: 24.hours
   end
 

--- a/lib/upright/version.rb
+++ b/lib/upright/version.rb
@@ -1,3 +1,3 @@
 module Upright
-  VERSION = "0.2.0"
+  VERSION = "0.3.1"
 end

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -24,7 +24,7 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
 
     sign_in
-    post "/alertmanager/api/v2/silences", params: silence_json, headers: { "Content-Type" => "application/json" }
+    post "/alertmanager/api/v2/silences", params: silence_json, headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
     assert_requested stub

--- a/test/integration/alertmanager_proxy_controller_test.rb
+++ b/test/integration/alertmanager_proxy_controller_test.rb
@@ -11,7 +11,7 @@ class AlertmanagerProxyControllerTest < ActionDispatch::IntegrationTest
       .to_return(status: 200, body: "Alertmanager UI")
 
     sign_in
-    get "/alertmanager"
+    get "/alertmanager", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end

--- a/test/integration/login_csrf_test.rb
+++ b/test/integration/login_csrf_test.rb
@@ -1,0 +1,65 @@
+require "test_helper"
+
+# Regression coverage for CVE-2026-67993 (login CSRF via the static_credentials
+# callback). These tests must run with request forgery protection ENABLED — the
+# suite otherwise disables it (see test/dummy/config/environments/test.rb), which
+# would make every assertion below pass for the wrong reason.
+class LoginCsrfTest < ActionDispatch::IntegrationTest
+  setup do
+    on_subdomain :app
+
+    @forgery_protection_was = ActionController::Base.allow_forgery_protection
+    ActionController::Base.allow_forgery_protection = true
+
+    # test_mode lets us stand in a "valid" credential result without depending on
+    # the configured password: the point under test is that CSRF/method guards
+    # refuse the forged request even when the credentials would have been accepted.
+    OmniAuth.config.test_mode = true
+    OmniAuth.config.mock_auth[:static_credentials] = OmniAuth::AuthHash.new(
+      provider: "static_credentials",
+      uid: "admin",
+      info: { email: "admin@localhost", name: "admin" }
+    )
+  end
+
+  teardown do
+    ActionController::Base.allow_forgery_protection = @forgery_protection_was
+    OmniAuth.config.test_mode = false
+    OmniAuth.config.mock_auth[:static_credentials] = nil
+  end
+
+  test "a cross-site GET to the credential callback cannot plant a session" do
+    get "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :not_found
+    assert_nil session[:user_info]
+  end
+
+  test "a HEAD to the credential callback cannot plant a session" do
+    head "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :not_found
+    assert_nil session[:user_info]
+  end
+
+  test "a cross-origin POST without a valid authenticity token is refused" do
+    post "/auth/static_credentials/callback", params: { username: "admin", password: "known-to-attacker" }
+
+    assert_response :unprocessable_content
+    assert_nil session[:user_info]
+  end
+
+  test "the same-origin sign-in form still signs in" do
+    get upright.new_admin_session_path
+    assert_response :success
+
+    token = css_select("input[name='authenticity_token']").first&.[]("value")
+    assert token.present?, "the sign-in form should carry a Rails authenticity token"
+
+    post "/auth/static_credentials/callback",
+      params: { username: "admin", password: "irrelevant-in-test-mode", authenticity_token: token }
+
+    assert_redirected_to upright.root_path
+    assert session[:user_info].present?
+  end
+end

--- a/test/integration/prometheus_proxy_controller_test.rb
+++ b/test/integration/prometheus_proxy_controller_test.rb
@@ -11,7 +11,7 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
     stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
     sign_in
 
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :success
   end
@@ -26,7 +26,7 @@ class PrometheusProxyControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "proxy requires authentication" do
-    get "/prometheus/graph"
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
 
     assert_response :redirect
     assert response.location.end_with?("/session/new")

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -119,6 +119,14 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested stub
   end
 
+  test "a same-site navigation to the framed proxy page is allowed (post-login return)" do
+    sign_in
+
+    get "/framed/prometheus", headers: { "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "navigate" }
+
+    assert_response :success
+  end
+
   test "a normal query still forwards on the session path" do
     stub_request(:get, "http://localhost:9090/api/v1/query?query=up").to_return(status: 200, body: "{}")
     sign_in

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -1,0 +1,129 @@
+require "test_helper"
+require "webmock/minitest"
+
+# Regression coverage for CVE-2026-67990 (proxy CSRF). A browser request on the
+# session-cookie path must be refused when it originates cross-site, so a forged
+# request can't ride the victim's Lax session cookie into upstream write/admin
+# APIs. Genuine same-origin calls from the embedded UI still forward, and the
+# token-authenticated OTLP endpoint stays on its own 401 path.
+class ProxyCsrfTest < ActionDispatch::IntegrationTest
+  setup do
+    on_subdomain :app
+    ENV["PROMETHEUS_OTLP_TOKEN"] = "test-token"
+  end
+
+  # --- The forged cross-site vectors are refused, POST and the Lax-cookie GET ---
+
+  test "cross-site POST to alertmanager on the session path is forbidden" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "forged" }.to_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "cross-site GET to prometheus on the session path is forbidden" do
+    stub = stub_request(:get, "http://localhost:9090/-/reload")
+    sign_in
+
+    # Top-level Lax-cookie navigation vector: a cross-site GET carries no Origin
+    # header, only Sec-Fetch-Site.
+    get "/prometheus/-/reload", headers: { "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "foreign Origin on the session path is forbidden when Sec-Fetch is absent" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "forged" }.to_json,
+      headers: { "Content-Type" => "application/json", "Origin" => "https://evil.example" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  # --- Legitimate traffic still forwards ---
+
+  test "same-origin session request forwards to prometheus" do
+    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+    sign_in
+
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+  end
+
+  test "same-origin session request forwards a write to alertmanager" do
+    silence_json = { comment: "real" }.to_json
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+      .with(body: silence_json)
+      .to_return(status: 200, body: '{"silenceID":"abc-123"}', headers: { "Content-Type" => "application/json" })
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: silence_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+    assert_requested stub
+  end
+
+  test "OTLP stays on its token path: no token is unauthorized, not forbidden" do
+    post "/prometheus/api/v1/otlp/v1/metrics",
+      headers: { "Content-Type" => "application/x-protobuf", "Sec-Fetch-Site" => "cross-site" }
+
+    assert_response :unauthorized
+  end
+
+  # --- Tightened Fetch-Metadata policy ---
+
+  test "same-site sub-resource POST is refused" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "sibling" }.to_json,
+      headers: { "Content-Type" => "application/json", "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "cors" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "a session POST with no Fetch-Metadata and no Origin fails closed" do
+    stub = stub_request(:post, "http://localhost:9093/api/v2/silences")
+    sign_in
+
+    post "/alertmanager/api/v2/silences",
+      params: { comment: "old browser" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+
+    assert_response :forbidden
+    assert_not_requested stub
+  end
+
+  test "a same-site top-level GET navigation between our subdomains is allowed" do
+    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+    sign_in
+
+    get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "navigate" }
+
+    assert_response :success
+  end
+
+  test "a normal query still forwards on the session path" do
+    stub_request(:get, "http://localhost:9090/api/v1/query?query=up").to_return(status: 200, body: "{}")
+    sign_in
+
+    get "/prometheus/api/v1/query?query=up", headers: { "Sec-Fetch-Site" => "same-origin" }
+
+    assert_response :success
+  end
+end

--- a/test/integration/proxy_csrf_test.rb
+++ b/test/integration/proxy_csrf_test.rb
@@ -109,13 +109,14 @@ class ProxyCsrfTest < ActionDispatch::IntegrationTest
     assert_not_requested stub
   end
 
-  test "a same-site top-level GET navigation between our subdomains is allowed" do
-    stub_request(:get, "http://localhost:9090/graph").to_return(status: 200, body: "Prometheus UI")
+  test "a same-site request is refused (a sibling domain is same-site, not same-origin)" do
+    stub = stub_request(:get, "http://localhost:9090/graph")
     sign_in
 
     get "/prometheus/graph", headers: { "Sec-Fetch-Site" => "same-site", "Sec-Fetch-Mode" => "navigate" }
 
-    assert_response :success
+    assert_response :forbidden
+    assert_not_requested stub
   end
 
   test "a normal query still forwards on the session path" do

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -39,6 +39,11 @@ class ProxyPathSanitizationTest < ActiveSupport::TestCase
     assert_nil sanitize("/api/ query")
   end
 
+  test "rejects a path with a null byte or broken encoding" do
+    assert_nil sanitize("/api/v1/query\0")
+    assert_nil sanitize("/api/\xC3(")
+  end
+
   test "rejects an over-long query" do
     assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyGuards::MAX_UPSTREAM_QUERY + 1)))
   end

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -27,6 +27,13 @@ class ProxyPathSanitizationTest < ActiveSupport::TestCase
     assert_nil sanitize("/api/%2e%2e/secret")
   end
 
+  test "rejects a single-dot segment that URI#merge would collapse" do
+    assert_nil sanitize("/./-/reload")
+    assert_nil sanitize("/api/./v1")
+    assert_nil sanitize("/.")
+    assert_equal "/api/v1.json", sanitize("/api/v1.json")
+  end
+
   test "rejects characters outside the path set" do
     assert_nil sanitize("/api/v1/query\nHost: evil")
     assert_nil sanitize("/api/ query")

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -21,6 +21,12 @@ class ProxyPathSanitizationTest < ActiveSupport::TestCase
     assert_nil sanitize("/..")
   end
 
+  test "rejects percent-encoding in the path (double-encoding bypass)" do
+    assert_nil sanitize("/%2f%2fevil.example/steal")
+    assert_nil sanitize("/%252d%252freload")
+    assert_nil sanitize("/api/%2e%2e/secret")
+  end
+
   test "rejects characters outside the path set" do
     assert_nil sanitize("/api/v1/query\nHost: evil")
     assert_nil sanitize("/api/ query")

--- a/test/integration/proxy_path_sanitization_test.rb
+++ b/test/integration/proxy_path_sanitization_test.rb
@@ -1,0 +1,43 @@
+require "test_helper"
+
+# Unit coverage for the proxy path lock (WP1 / F-01 / CVE-2026-25765). These
+# assert the sanitizer directly because the Rack test client (like production
+# path normalization) can collapse a literal `//`, so the authority-override
+# vector is only faithfully exercised against the method itself.
+class ProxyPathSanitizationTest < ActiveSupport::TestCase
+  setup { @controller = Upright::PrometheusProxyController.new }
+
+  def sanitize(raw)
+    @controller.send(:sanitized_upstream_path, raw)
+  end
+
+  test "rejects a protocol-relative authority override" do
+    assert_nil sanitize("//evil.example/steal")
+    assert_nil sanitize("//169.254.169.254/latest/meta-data/")
+  end
+
+  test "rejects path traversal" do
+    assert_nil sanitize("/api/v1/../../etc/passwd")
+    assert_nil sanitize("/..")
+  end
+
+  test "rejects characters outside the path set" do
+    assert_nil sanitize("/api/v1/query\nHost: evil")
+    assert_nil sanitize("/api/ query")
+  end
+
+  test "rejects an over-long query" do
+    assert_nil sanitize("/api/v1/query?" + ("a" * (Upright::ProxyGuards::MAX_UPSTREAM_QUERY + 1)))
+  end
+
+  test "passes a normal path and query through unchanged" do
+    assert_equal "/api/v1/query?query=up", sanitize("/api/v1/query?query=up")
+    assert_equal "/graph", sanitize("/graph")
+    assert_equal "/", sanitize("")
+  end
+
+  test "the built request must stay on the configured upstream host" do
+    assert @controller.send(:upstream_host_ok?, "http://localhost:9090", "/api/v1/query")
+    refute @controller.send(:upstream_host_ok?, "http://localhost:9090", "//evil.example/x")
+  end
+end

--- a/test/lib/helpers/authentication_helper.rb
+++ b/test/lib/helpers/authentication_helper.rb
@@ -10,7 +10,9 @@ module AuthenticationHelper
     })
 
     on_subdomain :app
-    get upright.auth_callback_url(provider)
+    # Mirror the real sign-in form, which posts to the callback (see
+    # sessions#create's require_post_for_credential_callback guard).
+    post upright.auth_callback_url(provider)
   end
 
   def sign_out

--- a/test/lib/helpers/authentication_helper.rb
+++ b/test/lib/helpers/authentication_helper.rb
@@ -11,7 +11,7 @@ module AuthenticationHelper
 
     on_subdomain :app
     # Mirror the real sign-in form, which posts to the callback (see
-    # sessions#create's require_post_for_credential_callback guard).
+    # sessions#create's verify_credential_callback guard).
     post upright.auth_callback_url(provider)
   end
 

--- a/upright.gemspec
+++ b/upright.gemspec
@@ -39,6 +39,10 @@ Gem::Specification.new do |spec|
   spec.add_dependency "playwright-ruby-client", "~> 1.56"
 
   # Observability
+  # Floor faraday at 2.14.3: earlier releases resolve a protocol-relative path
+  # (`//host/…`) against the connection URL in a way that can retarget the
+  # request at another host (SSRF, CVE-2026-25765).
+  spec.add_dependency "faraday", ">= 2.14.3"
   spec.add_dependency "prometheus-api-client"
   spec.add_dependency "yabeda"
   spec.add_dependency "yabeda-prometheus"


### PR DESCRIPTION
Minimal security backport onto the 0.3.x line, for existing gem users who can't yet take the ~4 months of unreleased work on `main`. Base branch `0-3-stable` is pinned at the v0.3.0 release; this PR is the 0.3.1 content.

Ports only the fixes that apply to 0.3.0's code (re-implemented against it, not cherry-picked — 0.3.0 lacks the proxy-token substitute, the public-status feature, and the Playwright trace concern):

- **CVE-2026-67993** — login CSRF on the `static_credentials` callback: require a tokened POST; skip Rails' auto-check so a state-validated OIDC `form_post` callback still works; fail closed when `ADMIN_PASSWORD` is unset.
- **CVE-2026-67990** — proxy CSRF: a Fetch-Metadata / Origin gate on the session path (same-origin + user-initiated only; missing headers fail closed).
- **CVE-2026-25765** — proxy SSRF: path sanitizer (no authority override, dot-segments, or percent-encoding) + upstream-host re-check + `faraday >= 2.14.3`.
- **F-08** — scope the session cookie to the configured hostname via a Proc.

Matches the corresponding fixes in #126 (main) through both review rounds. Tests green locally (proxy/login/session suites); CI will confirm on Linux.

After merge: tag **v0.3.1** from `0-3-stable`.