### PR TITLE
Bump brakeman to 8.0.6

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,8 @@ updates:
     semver-minor-days: 3
     semver-patch-days: 2
     default-days: 7
+    exclude:
+      - "brakeman"
 - package-ecosystem: github-actions
   directory: "/"
   groups:

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -116,7 +116,7 @@ GEM
     base64 (0.3.0)
     bigdecimal (4.1.2)
     bindata (2.5.1)
-    brakeman (8.0.4)
+    brakeman (8.0.6)
       racc
     builder (3.3.0)
     cgi (0.5.1)
@@ -655,7 +655,7 @@ CHECKSUMS
   base64 (0.3.0) sha256=27337aeabad6ffae05c265c450490628ef3ebd4b67be58257393227588f5a97b
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindata (2.5.1) sha256=53186a1ec2da943d4cb413583d680644eb810aacbf8902497aac8f191fad9e58
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.6) sha256=759cc69341115e6c2dcd47b6fd8649a0b9bd540e3585ac8a0a94e31c66fee386
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   cgi (0.5.1) sha256=e93fcafc69b8a934fe1e6146121fa35430efa8b4a4047c4893764067036f18e9
   concurrent-ruby (1.3.8) sha256=b2f1be836e968ccc78ccfce277ea79c72a88633f22306782c16ff23fb415d1e1


### PR DESCRIPTION
brakeman here is at 8.0.4; 8.0.6 shipped on 2026-08-12. This repo's `bin/brakeman` does **not** pass `--ensure-latest`, so CI is green and this is a staleness fix rather than a red-build fix.

Supersedes #92 (dependabot's 8.0.4 → 8.0.5), which is now two releases behind.

Two commits:

1. **Lockfile bump to 8.0.6**, via `bundle lock --update brakeman`. brakeman's only runtime dependency is `racc` and its required ruby is `>= 3.2.0`, both unchanged since 7.1.2, so the diff is the version line and its checksum, and nothing else in the graph moves.
2. **brakeman exempted from the dependabot cooldown**, so the next release is proposed the week it ships instead of 7–14 days later.

Deliberately *not* done: adding `--ensure-latest` to `bin/brakeman`. Sibling repos in this sweep have it and it is exactly what turned their builds red; introducing that failure mode here would be a regression, not an improvement.

**Verified locally:** the lockfile diff is the brakeman line plus its checksum, and brakeman 8.0.6 scans this repo clean — 0 warnings, 0 errors, 0 obsolete ignore entries.

One of twelve repos in a fleet-wide sweep to 8.0.6. Needs a review approval before it can land.
