### PR TITLE
Compute service uptime from HTTP probes by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,7 +60,7 @@ upgrade does not rewrite. Existing installs should apply these by hand:
 
 ### Changed
 
-- Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`). Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page
+- Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`); a type not registered with `config.probe_types` raises. Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page. Rollups written before probe types were recorded keep counting
 - Roll up daily uptime from every `stores_metrics` site, preferring the best-covered instance per probe; skip and report probe-days below `config.rollup_minimum_coverage` instead of averaging a gappy window; correct rollups in place and backfill a week (#121). `upright:probe_down_fraction` now falls back to zero when no region is down, which the coverage count depends on; rules predating this need the same fallback, or `config.rollup_minimum_coverage = 0`
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ upgrade does not rewrite. Existing installs should apply these by hand:
 
 ### Changed
 
+- Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`). Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page
 - Roll up daily uptime from every `stores_metrics` site, preferring the best-covered instance per probe; skip and report probe-days below `config.rollup_minimum_coverage` instead of averaging a gappy window; correct rollups in place and backfill a week (#121). `upright:probe_down_fraction` now falls back to zero when no region is down, which the coverage count depends on; rules predating this need the same fallback, or `config.rollup_minimum_coverage = 0`
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)

--- a/app/models/concerns/upright/services/live_status.rb
+++ b/app/models/concerns/upright/services/live_status.rb
@@ -57,7 +57,13 @@ module Upright::Services::LiveStatus
     end
 
     def live_down_query
-      matchers = [ %(probe_service="#{code}"), %(environment="#{Rails.env}"), %(type=~"#{uptime_probe_types.join("|")}") ]
+      matchers = [ %(probe_service="#{code}"), %(environment="#{Rails.env}"), %(type=~"#{uptime_probe_types_pattern}") ]
       %(max(upright:probe_down_fraction{#{matchers.join(",")}}) or vector(0))
+    end
+
+    # Each type escaped as a regex literal, then the pattern escaped again for
+    # the PromQL string it sits in, so "api.v2" doesn't also match "apiXv2".
+    def uptime_probe_types_pattern
+      uptime_probe_types.map { |type| Regexp.escape(type) }.join("|").gsub(/["\\]/) { |char| "\\#{char}" }
     end
 end

--- a/app/models/concerns/upright/services/live_status.rb
+++ b/app/models/concerns/upright/services/live_status.rb
@@ -57,7 +57,7 @@ module Upright::Services::LiveStatus
     end
 
     def live_down_query
-      matchers = [ %(probe_service="#{code}"), %(environment="#{Rails.env}") ]
+      matchers = [ %(probe_service="#{code}"), %(environment="#{Rails.env}"), %(type=~"#{uptime_probe_types.join("|")}") ]
       %(max(upright:probe_down_fraction{#{matchers.join(",")}}) or vector(0))
     end
 end

--- a/app/models/upright/service.rb
+++ b/app/models/upright/service.rb
@@ -44,8 +44,17 @@ class Upright::Service < FrozenRecord::Base
     self[:incident_updates]&.fetch(key.to_s, nil)
   end
 
+  DEFAULT_UPTIME_PROBE_TYPES = %w[ http ]
+
+  # Probe types whose results decide this service's live status and daily
+  # uptime: HTTP unless `uptime_probe_types` in services.yml says otherwise.
+  # Other types bound to the service are still probed, rolled up and alerted on.
+  def uptime_probe_types
+    Array(self[:uptime_probe_types]).map(&:to_s).presence || DEFAULT_UPTIME_PROBE_TYPES
+  end
+
   def probe_rollups
-    Upright::Rollups::ProbeRollup.where(probe_service: code)
+    Upright::Rollups::ProbeRollup.where(probe_service: code, probe_type: uptime_probe_types)
   end
 
   def uptime_for(day)

--- a/app/models/upright/service.rb
+++ b/app/models/upright/service.rb
@@ -49,12 +49,23 @@ class Upright::Service < FrozenRecord::Base
   # Probe types whose results decide this service's live status and daily
   # uptime: HTTP unless `uptime_probe_types` in services.yml says otherwise.
   # Other types bound to the service are still probed, rolled up and alerted on.
+  # A type that isn't registered raises rather than matching nothing, since an
+  # empty match would report the service operational.
   def uptime_probe_types
-    Array(self[:uptime_probe_types]).map(&:to_s).presence || DEFAULT_UPTIME_PROBE_TYPES
+    types = Array(self[:uptime_probe_types]).map(&:to_s).presence || DEFAULT_UPTIME_PROBE_TYPES
+    unknown = types - Upright.configuration.probe_types.types
+
+    if unknown.any?
+      raise Upright::ConfigurationError, "#{code}: uptime_probe_types #{unknown.join(", ")} not registered with config.probe_types"
+    end
+
+    types
   end
 
+  # Rollups written before probe_type was recorded (July 2026) have none and
+  # keep counting, so an upgrade doesn't drop history.
   def probe_rollups
-    Upright::Rollups::ProbeRollup.where(probe_service: code, probe_type: uptime_probe_types)
+    Upright::Rollups::ProbeRollup.where(probe_service: code, probe_type: [ *uptime_probe_types, nil ])
   end
 
   def uptime_for(day)

--- a/test/dummy/config/services.yml
+++ b/test/dummy/config/services.yml
@@ -7,3 +7,4 @@
 - code: "internal_tools"
   name: "Internal Tools"
   public: false
+  uptime_probe_types: [http, playwright]

--- a/test/fixtures/upright_rollups_probe_rollups.yml
+++ b/test/fixtures/upright_rollups_probe_rollups.yml
@@ -19,6 +19,15 @@ example_api_may_05:
   uptime_fraction: 1.0
   status: operational
 
+example_flow_may_10:
+  probe_name: Sign-in flow
+  probe_type: playwright
+  probe_target: https://example.com/sign_in
+  probe_service: internal_tools
+  period_start: 2026-05-10 00:00:00
+  uptime_fraction: 0.5
+  status: major_outage
+
 example_web_may_11:
   probe_name: Web
   probe_type: http

--- a/test/fixtures/upright_rollups_probe_rollups.yml
+++ b/test/fixtures/upright_rollups_probe_rollups.yml
@@ -23,10 +23,26 @@ example_flow_may_10:
   probe_name: Sign-in flow
   probe_type: playwright
   probe_target: https://example.com/sign_in
+  probe_service: example_app
+  period_start: 2026-05-10 00:00:00
+  uptime_fraction: 0.5
+  status: major_outage
+
+internal_flow_may_10:
+  probe_name: Admin flow
+  probe_type: playwright
+  probe_target: https://example.com/admin
   probe_service: internal_tools
   period_start: 2026-05-10 00:00:00
   uptime_fraction: 0.5
   status: major_outage
+
+example_legacy_may_09:
+  probe_name: Web
+  probe_service: example_app
+  period_start: 2026-05-09 00:00:00
+  uptime_fraction: 0.7
+  status: partial_outage
 
 example_web_may_11:
   probe_name: Web

--- a/test/models/upright/service_live_status_test.rb
+++ b/test/models/upright/service_live_status_test.rb
@@ -30,6 +30,22 @@ class Upright::ServiceLiveStatusTest < ActiveSupport::TestCase
     assert_equal :operational, Upright::Service.find_by(code: "internal_tools").live_status
   end
 
+  test "live_status asks Prometheus about HTTP probes only by default" do
+    client = mock("prometheus")
+    client.expects(:query).with { |query:| query.include?(%(type=~"http")) && query.exclude?("playwright") }.returns({ "result" => [] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    assert_equal :operational, Upright::Service.find_by(code: "example_app").live_status
+  end
+
+  test "live_status asks about the service's extra uptime_probe_types" do
+    client = mock("prometheus")
+    client.expects(:query).with { |query:| query.include?(%(type=~"http|playwright")) }.returns({ "result" => [ { "value" => [ 1765000000, "1" ] } ] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    assert_equal :major_outage, Upright::Service.find_by(code: "internal_tools").live_status
+  end
+
   test "current_outage_started_at reuses a cached Prometheus range within the public cache window" do
     client = mock("prometheus")
     client.expects(:query_range).once.returns({ "result" => [ { "values" => [ [ 1765000000, "0" ], [ 1765000300, "1" ] ] } ] })

--- a/test/models/upright/service_live_status_test.rb
+++ b/test/models/upright/service_live_status_test.rb
@@ -46,6 +46,19 @@ class Upright::ServiceLiveStatusTest < ActiveSupport::TestCase
     assert_equal :major_outage, Upright::Service.find_by(code: "internal_tools").live_status
   end
 
+  test "live_status escapes probe types for the PromQL regex and string" do
+    Upright.configuration.probe_types.register "api.v2", name: "API v2", icon: "🔌"
+    service = Upright::Service.new(code: "escaped", name: "Escaped", uptime_probe_types: [ "api.v2" ])
+
+    client = mock("prometheus")
+    client.expects(:query).with { |query:| query.include?(%(type=~"api\\\\.v2")) }.returns({ "result" => [] })
+    Upright.stubs(:prometheus_client).returns(client)
+
+    assert_equal :operational, service.live_status
+  ensure
+    Upright.configuration.probe_types.unregister "api.v2"
+  end
+
   test "current_outage_started_at reuses a cached Prometheus range within the public cache window" do
     client = mock("prometheus")
     client.expects(:query_range).once.returns({ "result" => [ { "values" => [ [ 1765000000, "0" ], [ 1765000300, "1" ] ] } ] })

--- a/test/models/upright/service_test.rb
+++ b/test/models/upright/service_test.rb
@@ -33,12 +33,25 @@ class Upright::ServiceTest < ActiveSupport::TestCase
     assert_equal %w[ http playwright ], Upright::Service.find_by(code: "internal_tools").uptime_probe_types
   end
 
+  test "uptime_probe_types rejects a type that isn't registered" do
+    service = Upright::Service.new(code: "typo", name: "Typo", uptime_probe_types: [ "http", "playwrite" ])
+
+    error = assert_raises(Upright::ConfigurationError) { service.uptime_probe_types }
+    assert_match(/typo: uptime_probe_types playwrite not registered/, error.message)
+  end
+
   test "daily_uptime only counts the service's uptime probe types" do
     travel_to Date.new(2026, 5, 13) do
       may_10 = Date.new(2026, 5, 10).beginning_of_day
 
       assert_nil Upright::Service.find_by(code: "example_app").daily_uptime(past: 7.days)[may_10]
       assert_equal 0.5, Upright::Service.find_by(code: "internal_tools").daily_uptime(past: 7.days)[may_10]
+    end
+  end
+
+  test "daily_uptime keeps counting rollups recorded before probe_type existed" do
+    travel_to Date.new(2026, 5, 13) do
+      assert_equal 0.7, Upright::Service.find_by(code: "example_app").daily_uptime(past: 7.days)[Date.new(2026, 5, 9).beginning_of_day]
     end
   end
 

--- a/test/models/upright/service_test.rb
+++ b/test/models/upright/service_test.rb
@@ -28,6 +28,20 @@ class Upright::ServiceTest < ActiveSupport::TestCase
     assert_equal 0.85, service.uptime_for(day)
   end
 
+  test "uptime_probe_types defaults to HTTP and reads extra types from services.yml" do
+    assert_equal %w[ http ], Upright::Service.find_by(code: "example_app").uptime_probe_types
+    assert_equal %w[ http playwright ], Upright::Service.find_by(code: "internal_tools").uptime_probe_types
+  end
+
+  test "daily_uptime only counts the service's uptime probe types" do
+    travel_to Date.new(2026, 5, 13) do
+      may_10 = Date.new(2026, 5, 10).beginning_of_day
+
+      assert_nil Upright::Service.find_by(code: "example_app").daily_uptime(past: 7.days)[may_10]
+      assert_equal 0.5, Upright::Service.find_by(code: "internal_tools").daily_uptime(past: 7.days)[may_10]
+    end
+  end
+
   test "daily_uptime groups by day across the lookback window" do
     travel_to Date.new(2026, 5, 13) do
       service = Upright::Service.find_by(code: "example_app")


### PR DESCRIPTION
A service's live status and daily uptime on the public status page were computed from every probe bound to the service. A Playwright probe runs every 15 minutes, so one failed run recorded the whole interval as downtime: the recent Fizzy outage showed 16 minutes on the status page when the HTTP probes measured about 4.5.

Each service now reads its status and uptime from HTTP probes only. A service that wants other types counted lists them in `services.yml`:

```yaml
- code: "fizzy"
  name: "Fizzy"
  uptime_probe_types: [http, playwright]
```

The list is applied at the two read points:

- `Upright::Services::LiveStatus#live_down_query` adds a `type=~"..."` matcher, so today's bar, the public banner and `Service.degraded` (which feeds automatic incidents) only see those types.
- `Upright::Service#probe_rollups` filters by `probe_type`, so the 90-day bars and the uptime percentage only see those types.

Recording rules, stored rollups and alerts are unchanged. Types left out are still probed, rolled up and alerted on.

Basecamp: https://app.basecamp.com/2914079/buckets/43768667/card_tables/cards/10218414070

Tests: `bin/rails test`; `bin/rubocop`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
