### PR TITLE
Convert public status page timestamps to the visitor's time zone

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -60,6 +60,7 @@ upgrade does not rewrite. Existing installs should apply these by hand:
 
 ### Changed
 
+- Convert timestamps on the public status page to the visitor's time zone. The page now loads a JavaScript entry point of its own, `upright/public`, which carries only local-time; the admin app's modules are preloaded for the `application` entry point alone
 - Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`); a type not registered with `config.probe_types` raises. Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page. Rollups written before probe types were recorded keep counting
 - Roll up daily uptime from every `stores_metrics` site, preferring the best-covered instance per probe; skip and report probe-days below `config.rollup_minimum_coverage` instead of averaging a gappy window; correct rollups in place and backfill a week (#121). `upright:probe_down_fraction` now falls back to zero when no region is down, which the coverage count depends on; rules predating this need the same fallback, or `config.rollup_minimum_coverage = 0`
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)

--- a/app/javascript/upright/public.js
+++ b/app/javascript/upright/public.js
@@ -1,0 +1,5 @@
+// Entry point for the public status page. It loads only what that page uses:
+// local-time converts the server-rendered UTC timestamps to the visitor's zone.
+import LocalTime from "local-time"
+
+LocalTime.start()

--- a/app/views/layouts/upright/public.html.erb
+++ b/app/views/layouts/upright/public.html.erb
@@ -6,6 +6,7 @@
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
     <%= upright_stylesheet_link_tag "data-turbo-track": "reload" %>
+    <%= javascript_importmap_tags "upright/public" %>
   </head>
   <body class="public">
     <%= render "upright/public/branding" %>

--- a/config/importmap.rb
+++ b/config/importmap.rb
@@ -1,19 +1,29 @@
-# Pin engine JavaScript
-pin "application", to: "upright/application.js"
-pin "upright/application", to: "upright/application.js"
-pin "upright/controllers/application", to: "upright/controllers/application.js"
-pin "upright/controllers", to: "upright/controllers/index.js"
+# Two entry points share this map. The admin app loads "application"; the public
+# status page loads "upright/public". Pins used only by the admin app are
+# preloaded for the "application" entry point alone, so the public page does not
+# fetch Turbo, Stimulus, Leaflet or the charts library.
+
+# Admin app
+pin "application", to: "upright/application.js", preload: "application"
+pin "upright/application", to: "upright/application.js", preload: "application"
+pin "upright/controllers/application", to: "upright/controllers/application.js", preload: "application"
+pin "upright/controllers", to: "upright/controllers/index.js", preload: "application"
 
 pin_all_from Upright::Engine.root.join("app/javascript/upright/controllers"),
              under: "upright/controllers",
-             to: "upright/controllers"
+             to: "upright/controllers",
+             preload: "application"
 
-# Dependencies
-pin "@hotwired/turbo-rails", to: "https://cdn.jsdelivr.net/npm/@hotwired/turbo-rails@8.0.20/+esm"
-pin "@hotwired/turbo", to: "https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.20/+esm"
-pin "@hotwired/stimulus", to: "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/dist/stimulus.js"
-pin "@hotwired/stimulus-loading", to: "stimulus-loading.js"
-pin "@rails/actioncable/src", to: "https://cdn.jsdelivr.net/npm/@rails/actioncable@8.1.100/src/index.js"
-pin "leaflet", to: "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet-src.esm.js"
-pin "frappe-charts", to: "https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.esm.js"
+pin "@hotwired/turbo-rails", to: "https://cdn.jsdelivr.net/npm/@hotwired/turbo-rails@8.0.20/+esm", preload: "application"
+pin "@hotwired/turbo", to: "https://cdn.jsdelivr.net/npm/@hotwired/turbo@8.0.20/+esm", preload: "application"
+pin "@hotwired/stimulus", to: "https://cdn.jsdelivr.net/npm/@hotwired/stimulus@3.2.2/dist/stimulus.js", preload: "application"
+pin "@hotwired/stimulus-loading", to: "stimulus-loading.js", preload: "application"
+pin "@rails/actioncable/src", to: "https://cdn.jsdelivr.net/npm/@rails/actioncable@8.1.100/src/index.js", preload: "application"
+pin "leaflet", to: "https://cdn.jsdelivr.net/npm/leaflet@1.9.4/dist/leaflet-src.esm.js", preload: "application"
+pin "frappe-charts", to: "https://cdn.jsdelivr.net/npm/frappe-charts@1.6.2/dist/frappe-charts.min.esm.js", preload: "application"
+
+# Public status page
+pin "upright/public", to: "upright/public.js", preload: "upright/public"
+
+# Shared
 pin "local-time", to: "local-time.es2017-esm.js", preload: true

--- a/test/integration/public/services_controller_test.rb
+++ b/test/integration/public/services_controller_test.rb
@@ -15,6 +15,16 @@ class Upright::Public::ServicesControllerTest < ActionDispatch::IntegrationTest
     assert_equal "max-age=15, public", response.headers["Cache-Control"]
   end
 
+  test "index loads only the public JavaScript entry point" do
+    get upright.public_services_root_path
+
+    assert_response :success
+    assert_match %(import "upright/public"), response.body
+    assert_match %r{<link rel="modulepreload" href="[^"]*local-time}, response.body
+    assert_no_match(/import "application"/, response.body)
+    assert_no_match(%r{<link rel="modulepreload" href="[^"]*(turbo|stimulus|leaflet|frappe)}, response.body)
+  end
+
   test "feed renders an RSS document" do
     get upright.public_services_feed_path
 

--- a/test/integration/sites_controller_test.rb
+++ b/test/integration/sites_controller_test.rb
@@ -18,4 +18,16 @@ class SitesControllerTest < ActionDispatch::IntegrationTest
     assert_response :success
     assert_equal "sites", @controller.controller_name
   end
+
+  test "admin pages load the application entry point with its modules preloaded" do
+    on_subdomain "app"
+    sign_in
+
+    get upright.root_path
+
+    assert_response :success
+    assert_match %(import "application"), response.body
+    assert_match %r{<link rel="modulepreload" href="[^"]*turbo}, response.body
+    assert_match %r{<link rel="modulepreload" href="[^"]*local-time}, response.body
+  end
 end


### PR DESCRIPTION
## Summary

- The public templates already render times through the `local_time` helpers, but the public layout loaded no JavaScript, so `LocalTime.start()` never ran there. Visitors saw the server-rendered UTC fallback, for example "Sep 3, 09:19 UTC".
- Add a public entry point, `upright/public`, that imports local-time and starts it, and load it from the public layout.
- Preload the admin-only pins for the `application` entry point alone. Without this the public page emits modulepreload links for Turbo, Stimulus, Leaflet and the charts library, and browsers fetch all of them.

## Test plan

- [x] `bin/rails test` passes (374 runs)
- [x] New test: the public page loads only `upright/public` and preloads local-time, with none of the admin modules
- [x] New test: the admin root still loads `application` with Turbo and local-time preloaded
- [x] Checked in a browser against the dummy app: an incident update stamped 09:40 UTC renders as "Sep 3, 10:40 BST"

🤖 Generated with [Claude Code](https://claude.com/claude-code)