### PR TITLE
Prepare 0.4.0: changelog, generator fixes, and a 0.3 to 0.4 upgrade guide

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -57,16 +57,19 @@ upgrade does not rewrite. Existing installs should apply these by hand:
   - `health_metrics` (`Upright::HealthMetricsJob`, every minute), which exports
     `upright_primary_site`, `upright_persistent_db_up` and
     `upright_rollup_last_run_timestamp_seconds`.
-  - `aggregate_rollups` (`Upright::Rollups::DailyAggregationJob`, hourly), which
-    writes the daily uptime the public status page shows.
-  - `report_incidents` (`Upright::IncidentReporterJob`, every 30 seconds), which
-    opens and resolves incidents from probe results.
-  - `advance_maintenances` (`Upright::MaintenanceAdvanceJob`, every 15 seconds),
-    which starts and completes scheduled maintenance windows on time.
-- `config/database.yml`: add a `persistent` database for rollups and incidents,
-  with `migrations_paths` pointing at the gem's `db/persistent_migrate`, and
-  include it in `db:prepare`. Status history lives there so it survives a
-  site's probe data being purged.
+  - Only with the public status page enabled: `aggregate_rollups`
+    (`Upright::Rollups::DailyAggregationJob`, hourly), which writes the daily
+    uptime the page shows; `report_incidents` (`Upright::IncidentReporterJob`,
+    every 30 seconds), which opens and resolves incidents from probe results;
+    and `advance_maintenances` (`Upright::MaintenanceAdvanceJob`, every 15
+    seconds), which starts and completes scheduled maintenance windows on time.
+- `config/database.yml`: add a `persistent` database for rollups, incidents and
+  maintenance windows, with `migrations_paths` pointing at the gem's
+  `db/persistent_migrate`; the install generator now writes it for new apps.
+  Status history lives there so it survives a site's probe data being purged.
+
+`UPGRADING.md` walks through every step from 0.3 to 0.4 with the config to
+copy.
 - `config/initializers/content_security_policy.rb`: adopt the recommended policy
   from the install template if you don't already enforce a CSP.
 - `config/initializers/upright.rb`: trace artifacts now link to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -49,9 +49,24 @@ upgrade does not rewrite. Existing installs should apply these by hand:
 - `config/initializers/omniauth.rb`: fail closed when `ADMIN_PASSWORD` is unset
   instead of `ENV.fetch("ADMIN_PASSWORD", "upright")`, so the well-known default
   password is removed (compare against the current install template).
-- `config/recurring.yml`: add the `sweep_playwright_videos` entry
-  (`class: "Upright::PlaywrightVideoSweepJob"`) so stranded recordings from a
-  crashed run are still cleaned up.
+- `config/recurring.yml`: existing installs need these entries, which the
+  install generator now writes for new ones. Compare against the template in
+  `lib/generators/upright/install/templates/recurring.yml`:
+  - `sweep_playwright_videos` (`Upright::PlaywrightVideoSweepJob`, hourly), so
+    stranded recordings from a crashed run are still cleaned up.
+  - `health_metrics` (`Upright::HealthMetricsJob`, every minute), which exports
+    `upright_primary_site`, `upright_persistent_db_up` and
+    `upright_rollup_last_run_timestamp_seconds`.
+  - `aggregate_rollups` (`Upright::Rollups::DailyAggregationJob`, hourly), which
+    writes the daily uptime the public status page shows.
+  - `report_incidents` (`Upright::IncidentReporterJob`, every 30 seconds), which
+    opens and resolves incidents from probe results.
+  - `advance_maintenances` (`Upright::MaintenanceAdvanceJob`, every 15 seconds),
+    which starts and completes scheduled maintenance windows on time.
+- `config/database.yml`: add a `persistent` database for rollups and incidents,
+  with `migrations_paths` pointing at the gem's `db/persistent_migrate`, and
+  include it in `db:prepare`. Status history lives there so it survives a
+  site's probe data being purged.
 - `config/initializers/content_security_policy.rb`: adopt the recommended policy
   from the install template if you don't already enforce a CSP.
 - `config/initializers/upright.rb`: trace artifacts now link to
@@ -61,10 +76,12 @@ upgrade does not rewrite. Existing installs should apply these by hand:
 ### Changed
 
 - Publish Prometheus and Alertmanager on loopback ports instead of `network_mode: host` in the generated and dummy `docker-compose.yml`, and scrape the app through `host.docker.internal`, so the development services work on macOS and Windows Docker Desktop as well as Linux (#54)
-- Convert timestamps on the public status page to the visitor's time zone. The page now loads a JavaScript entry point of its own, `upright/public`, which carries only local-time; the admin app's modules are preloaded for the `application` entry point alone
-- Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`); a type not registered with `config.probe_types` raises. Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page. Rollups written before probe types were recorded keep counting
+- Open, escalate and resolve incidents automatically from probe results: a service that stops passing gets an incident with a fixed "investigating" update, its impact follows the probes, and it resolves after five minutes of continuous recovery. `Upright::IncidentReporterJob` runs from `recurring.yml`; incidents also get operator shortcuts and a public per-service history (#137)
+- Convert timestamps on the public status page to the visitor's time zone. The page now loads a JavaScript entry point of its own, `upright/public`, which carries only local-time; the admin app's modules are preloaded for the `application` entry point alone (#141)
+- Compute a service's live status and daily uptime from its HTTP probes only. A service that wants other types counted lists them under `uptime_probe_types` in services.yml (`[http, playwright]`); a type not registered with `config.probe_types` raises. Types left out are still probed, rolled up and alerted on; this keeps a 15-minute Playwright probe from recording its whole interval as downtime on the status page. Rollups written before probe types were recorded keep counting (#138)
 - Roll up daily uptime from every `stores_metrics` site, preferring the best-covered instance per probe; skip and report probe-days below `config.rollup_minimum_coverage` instead of averaging a gappy window; correct rollups in place and backfill a week (#121). `upright:probe_down_fraction` now falls back to zero when no region is down, which the coverage count depends on; rules predating this need the same fallback, or `config.rollup_minimum_coverage = 0`
 - Add public status pages: live status, 90-day history, and an RSS feed (#79)
+- Use OpenStreetMap tiles for the sites map in both colour schemes instead of CARTO's dark tiles, which need an API key; the map's dark mode is now a CSS filter over the same tiles. The install generator's CSP template no longer allows `basemaps.cartocdn.com`
 - Export `upright_primary_site`, `upright_persistent_db_up`, and `upright_rollup_last_run_timestamp_seconds` for failover alerting; sites declare `primary: true`, and existing installs need `Upright::HealthMetricsJob` adding to `recurring.yml` (#116)
 - Add incidents and scheduled maintenance, with a public timeline and impact banner (#102)
 - Record who created and updated each incident (#105)

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ rails new my-upright --database=sqlite3 --skip-test
 cd my-upright
 bundle add upright
 bin/rails generate upright:install
-bin/rails db:migrate
+bin/rails db:prepare
 ```
 
 Start the server:
@@ -76,6 +76,8 @@ Visit http://app.my-upright.localhost:3000 to see your Upright instance.
 
 The `upright:install` generator creates:
 
+- `config/database.yml` - Development and test split into `primary` (probe results), `persistent` (rollups and incidents, migrated from the gem) and `queue` (Solid Queue) databases
+- `config/recurring.yml` - Probe schedules and the engine's housekeeping, health, rollup, incident and maintenance jobs
 - `config/initializers/upright.rb` - Engine configuration
 - `config/initializers/content_security_policy.rb` - Ready-to-enable CSP covering the engine's CDN dependencies
 - `config/sites.yml` - Site definitions for each VPS you host Upright on

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -1,0 +1,238 @@
+# Upgrading Upright
+
+## From 0.3 to 0.4
+
+0.4 adds an optional public status page with incidents and scheduled
+maintenance, a second database for the data behind them, several security fixes
+to generated config, and a Playwright that runs in-process instead of against a
+browser server. The gem upgrade does none of the host-app changes for you.
+Steps 1 to 9 apply to every install. Step 10 is only for installs that turn the
+status page on. Check the result at the end.
+
+### 1. Update the gem
+
+```sh
+bundle update upright
+```
+
+This also raises `faraday` to at least 2.14.3, which closes an SSRF in the
+Prometheus and Alertmanager proxies.
+
+### 2. Add the persistent database
+
+Rollups, incidents and maintenance windows live in a database of their own so
+status history survives a site's probe data being purged. Its migrations ship
+with the gem. Add a `persistent` entry next to `primary` and `queue` in
+`config/database.yml` for every environment, and point its migrations at the
+installed gem:
+
+```yaml
+development:
+  primary:
+    <<: *default
+    database: storage/development.sqlite3
+  persistent:
+    <<: *default
+    database: storage/development_persistent.sqlite3
+    migrations_paths: <%= Gem.loaded_specs["upright"].gem_dir %>/db/persistent_migrate
+  queue:
+    <<: *default
+    database: storage/development_queue.sqlite3
+    migrations_paths: db/queue_migrate
+```
+
+For MySQL or PostgreSQL, give `persistent` its own database name. If you run
+more than one site, they should share one persistent database, replicated if
+you need it to survive a site.
+
+Then create and migrate everything. This also runs a new `primary` migration
+that gives probe result durations sub-second precision:
+
+```sh
+bin/rails db:prepare
+```
+
+### 3. Schedule the new housekeeping and health jobs
+
+Add these to `config/recurring.yml` under each deployed environment. They match
+the install generator's template.
+
+```yaml
+  sweep_playwright_videos:
+    class: "Upright::PlaywrightVideoSweepJob"
+    schedule: every hour at minute 45
+
+  health_metrics:
+    class: "Upright::HealthMetricsJob"
+    schedule: every minute
+```
+
+`sweep_playwright_videos` removes recordings a crashed probe run leaves
+behind. `health_metrics` exports `upright_primary_site`,
+`upright_persistent_db_up` and `upright_rollup_last_run_timestamp_seconds` for
+failover alerting. The status page's jobs are in step 10.
+
+### 4. Mark the sites that hold metrics
+
+In `config/sites.yml`, add `stores_metrics: true` to every site that runs
+Prometheus, and `primary: true` to the one whose data is authoritative:
+
+```yaml
+    - code: ams
+      city: Amsterdam
+      country: NL
+      geohash: u17982
+      stores_metrics: true
+      primary: true
+```
+
+The Prometheus and Alertmanager proxies are served on every `stores_metrics`
+site, not only the app subdomain, and rollups read from all of them.
+
+### 5. Update the initializer
+
+Compare `config/initializers/upright.rb` with the install generator's template
+and add:
+
+- `config.proxy_token`. A token that collectors writing metrics and peer sites
+  reading the proxies present instead of an admin session. Every site must use
+  the same value. The template reads it from `PROMETHEUS_OTLP_TOKEN`; add that
+  as a Kamal secret.
+- `config.playwright_cli_path` replaces `config.playwright_server_url`. Probes
+  now launch Playwright directly. Remove the old setting.
+- `config.trace_viewer_url` if you do not want trace links to open in
+  `https://trace.playwright.dev`. Point it at a viewer you host, or set it to
+  nil to make traces download-only.
+
+### 6. Regenerate the Prometheus recording rules
+
+The recording rules now carry a `probe_service` label so the status page and
+rollups can read status per service, and `upright:probe_down_fraction` falls
+back to zero when no region is down. Copy
+`lib/generators/upright/install/templates/upright.rules.yml` from the gem over
+`config/prometheus/rules/upright.rules.yml`, keeping any alerts of your own,
+and redeploy Prometheus. The fallback matters once the status page's
+`aggregate_rollups` job runs: without it the coverage check skips healthy days.
+If you cannot update the rules yet, set `config.rollup_minimum_coverage = 0`.
+
+### 7. Fail closed on the admin password
+
+`config/initializers/omniauth.rb` used to default the admin password to
+`upright`. Replace the credentials line so the static provider is left
+unconfigured when `ADMIN_PASSWORD` is unset:
+
+```ruby
+admin_password = ENV["ADMIN_PASSWORD"].presence
+# ...
+credentials: admin_password ? { "admin" => admin_password } : {}
+```
+
+Add `ADMIN_PASSWORD` to your Kamal secrets. Without it nobody can sign in with
+the static provider, which is the intended behaviour.
+
+### 8. Run Playwright in the app container
+
+Probes launch Playwright directly, so the browser must be installed where the
+jobs run.
+
+- Remove the `playwright` accessory from `config/deploy.yml` and the
+  Playwright service from `docker-compose.yml`.
+- Update the `Dockerfile` from the generator template. It installs Node, then
+  `playwright` at `Upright::PLAYWRIGHT_VERSION` with the Chromium browser, in a
+  layer that is cached across code-only deploys.
+- In development, run `npx playwright install chromium` once.
+
+### 9. Harden the deploy config
+
+From the `config/deploy.yml` template:
+
+- The OpenTelemetry collector no longer mounts the Docker socket or the host's
+  container logs, no longer runs as root, and is pinned by image digest. Remove
+  the `volumes` and `options` blocks from the `otel_collector` accessory.
+- Prometheus no longer publishes a port and no longer enables
+  `--web.enable-lifecycle`. The app reaches it over the Docker network and
+  proxies it.
+- The collector's OTLP receiver listens on the Docker network only; see the
+  comment in the `otel_collector.yml` template.
+
+#### Content Security Policy (optional)
+
+`config/initializers/content_security_policy.rb` from the template covers the
+engine's CDN dependencies, the OpenStreetMap tiles the sites map now uses, and
+the trace viewer. Merge it into your policy if you enforce one. The old
+`basemaps.cartocdn.com` host is no longer needed.
+
+### 10. Only if you enable the public status page
+
+The status page is off by default. Everything in this step can be skipped if
+you leave it off.
+
+Turn it on in `config/initializers/upright.rb`:
+
+```ruby
+config.public_status_enabled = true
+config.public_status_custom_domains = [ "status.example.com" ]
+```
+
+Add the page's hostname to the proxy hosts in `config/deploy.yml` and to DNS.
+`config.public_stylesheets` lets you override its stylesheets and views.
+`config.rollup_minimum_coverage` skips a probe-day with too few samples rather
+than averaging it; the default is fine to start with.
+
+Schedule the jobs that build its history, open its incidents and run its
+maintenance windows:
+
+```yaml
+  aggregate_rollups:
+    class: "Upright::Rollups::DailyAggregationJob"
+    schedule: every hour at minute 5
+
+  report_incidents:
+    class: "Upright::IncidentReporterJob"
+    schedule: "*/30 * * * * *"
+
+  advance_maintenances:
+    class: "Upright::MaintenanceAdvanceJob"
+    schedule: "*/15 * * * * *"
+```
+
+`aggregate_rollups` writes the daily uptime the page shows and backfills a
+week on first run. `report_incidents` opens an incident when a public service
+stops passing its probes and resolves it after five minutes of recovery.
+`advance_maintenances` starts and completes scheduled maintenance windows on
+time.
+
+Then group probes into the services the page lists. Create `config/services.yml` and add a `service:` key to each probe definition
+in `probes/*.yml` naming the service it belongs to:
+
+```yaml
+# config/services.yml
+- code: app
+  name: Example App
+  url: app.example.com
+  public: true
+```
+
+- `public: true` shows the service on the status page. Others stay internal.
+- `uptime_probe_types` lists the probe types that decide live status and
+  uptime. The default is `[http]`. Add `playwright` to count those runs too; a
+  probe on a 15-minute interval records its whole interval as downtime when one
+  run fails.
+- `incident_updates` overrides the automatic incident text per service, with
+  keys `down`, `investigating` and `back_up`.
+
+Set `config.services_path` if the file lives elsewhere. Order in the file is
+the display order.
+
+### 11. Check the result
+
+```sh
+bin/rails runner 'puts Upright::PersistentRecord.up?'   # true
+bin/rails runner 'puts Upright::Service.count'          # 0 unless you did step 10
+```
+
+After deploying, confirm on each site that `upright_primary_site` and
+`upright_persistent_db_up` are present in Prometheus, that the status page
+answers on its hostname if you enabled it, and that a probe run records a
+result. The first daily uptime bars appear after `aggregate_rollups` has run
+and a week of history has been backfilled.

--- a/lib/generators/upright/install/database_config.rb
+++ b/lib/generators/upright/install/database_config.rb
@@ -1,0 +1,46 @@
+module Upright
+  module Generators
+    # Rewrites the single-database development and test entries that `rails new`
+    # writes into the three databases Upright uses:
+    #
+    #   primary     probe results and Active Storage artifacts
+    #   persistent  rollups, incidents and maintenance windows, which outlive a
+    #               site's probe data; its migrations ship with the gem
+    #   queue       Solid Queue
+    #
+    # Pure string transformation so the install generator's edit can be tested
+    # without a generated application.
+    module DatabaseConfig
+      ENVIRONMENTS = %w[development test].freeze
+
+      PERSISTENT_MIGRATIONS = %(<%= Gem.loaded_specs["upright"].gem_dir %>/db/persistent_migrate)
+
+      def self.rewrite(yaml)
+        ENVIRONMENTS.reduce(yaml) do |rewritten, env|
+          rewritten.sub(single_database(env), split_databases(env))
+        end
+      end
+
+      def self.single_database(env)
+        "#{env}:\n  <<: *default\n  database: storage/#{env}.sqlite3"
+      end
+
+      def self.split_databases(env)
+        <<~YAML.chomp
+          #{env}:
+            primary:
+              <<: *default
+              database: storage/#{env}.sqlite3
+            persistent:
+              <<: *default
+              database: storage/#{env}_persistent.sqlite3
+              migrations_paths: #{PERSISTENT_MIGRATIONS}
+            queue:
+              <<: *default
+              database: storage/#{env}_queue.sqlite3
+              migrations_paths: db/queue_migrate
+        YAML
+      end
+    end
+  end
+end

--- a/lib/generators/upright/install/install_generator.rb
+++ b/lib/generators/upright/install/install_generator.rb
@@ -1,3 +1,5 @@
+require_relative "database_config"
+
 module Upright
   module Generators
     class InstallGenerator < Rails::Generators::Base
@@ -62,14 +64,14 @@ module Upright
         rails_command "solid_queue:install"
       end
 
-      def add_queue_database
-        gsub_file "config/database.yml",
-          "development:\n  <<: *default\n  database: storage/development.sqlite3",
-          "development:\n  primary:\n    <<: *default\n    database: storage/development.sqlite3\n  queue:\n    <<: *default\n    database: storage/development_queue.sqlite3\n    migrations_paths: db/queue_migrate"
-
-        gsub_file "config/database.yml",
-          "test:\n  <<: *default\n  database: storage/test.sqlite3",
-          "test:\n  primary:\n    <<: *default\n    database: storage/test.sqlite3\n  queue:\n    <<: *default\n    database: storage/test_queue.sqlite3\n    migrations_paths: db/queue_migrate"
+      # Splits the development and test databases into primary, persistent and
+      # queue. The persistent database holds rollups, incidents and maintenance
+      # windows, and its migrations come from the gem, so database.yml points
+      # migrations_paths at the installed gem's db/persistent_migrate.
+      def add_persistent_and_queue_databases
+        gsub_file "config/database.yml", /\A.*\z/m do |yaml|
+          DatabaseConfig.rewrite(yaml)
+        end
       end
 
       def copy_recurring_config
@@ -107,7 +109,7 @@ module Upright
         say "Upright has been installed!", :green
         say ""
         say "Next steps:"
-        say "  1. Prepare the database: bin/rails db:prepare"
+        say "  1. Prepare the databases (primary, persistent and queue): bin/rails db:prepare"
         say "  2. Configure your servers in config/deploy.yml"
         say "  3. Configure sites in config/sites.yml"
         say "  4. Add probes in probes/*.yml"

--- a/lib/generators/upright/install/templates/recurring.yml
+++ b/lib/generators/upright/install/templates/recurring.yml
@@ -32,6 +32,14 @@ production:
     class: "Upright::HealthMetricsJob"
     schedule: every minute
 
+  aggregate_rollups:
+    class: "Upright::Rollups::DailyAggregationJob"
+    schedule: every hour at minute 5
+
+  advance_maintenances:
+    class: "Upright::MaintenanceAdvanceJob"
+    schedule: "*/15 * * * * *"
+
   report_incidents:
     class: "Upright::IncidentReporterJob"
     schedule: "*/30 * * * * *"

--- a/test/generators/database_config_test.rb
+++ b/test/generators/database_config_test.rb
@@ -1,0 +1,62 @@
+require "test_helper"
+require "generators/upright/install/database_config"
+
+class Upright::Generators::DatabaseConfigTest < ActiveSupport::TestCase
+  RAILS_DEFAULT = <<~YAML
+    default: &default
+      adapter: sqlite3
+      pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+      timeout: 5000
+
+    development:
+      <<: *default
+      database: storage/development.sqlite3
+
+    test:
+      <<: *default
+      database: storage/test.sqlite3
+
+    production:
+      primary:
+        <<: *default
+        database: storage/production.sqlite3
+  YAML
+
+  test "splits development and test into primary, persistent and queue databases" do
+    config = load(Upright::Generators::DatabaseConfig.rewrite(RAILS_DEFAULT))
+
+    %w[development test].each do |env|
+      assert_equal %w[primary persistent queue], config.fetch(env).keys
+      assert_equal "storage/#{env}.sqlite3", config.dig(env, "primary", "database")
+      assert_equal "storage/#{env}_persistent.sqlite3", config.dig(env, "persistent", "database")
+      assert_equal "storage/#{env}_queue.sqlite3", config.dig(env, "queue", "database")
+      assert_equal "db/queue_migrate", config.dig(env, "queue", "migrations_paths")
+    end
+  end
+
+  test "points the persistent database's migrations at the installed gem" do
+    config = load(Upright::Generators::DatabaseConfig.rewrite(RAILS_DEFAULT))
+
+    migrations_path = config.dig("development", "persistent", "migrations_paths")
+    assert_equal Upright::Engine.root.join("db/persistent_migrate").to_s, migrations_path
+    assert Dir.exist?(migrations_path)
+  end
+
+  test "leaves production and the defaults alone" do
+    rewritten = Upright::Generators::DatabaseConfig.rewrite(RAILS_DEFAULT)
+
+    assert_includes rewritten, "default: &default\n  adapter: sqlite3"
+    assert_includes rewritten, "production:\n  primary:\n    <<: *default\n    database: storage/production.sqlite3"
+  end
+
+  test "does nothing to a database.yml that already differs from the Rails default" do
+    custom = "development:\n  primary:\n    adapter: mysql2\n"
+
+    assert_equal custom, Upright::Generators::DatabaseConfig.rewrite(custom)
+  end
+
+  private
+    def load(yaml)
+      YAML.safe_load(ERB.new(yaml).result, aliases: true)
+    end
+end


### PR DESCRIPTION
Preparation for 0.4.0. Audited every PR merged since v0.3.0 against the changelog and the install generator, and wrote the upgrade guide.

## Changelog

- Added automatic incident reporting (#137), which was missing entirely.
- Added the switch from CARTO to OpenStreetMap map tiles (fad2d05), which was missing entirely and also changes the generated CSP template.
- Added PR numbers to the uptime-from-HTTP-probes (#138) and visitor-local-time (#141) entries.
- Rewrote the `recurring.yml` item under Upgrading to list every entry an existing install needs, with the status page's three jobs marked as opt-in.
- Added the `persistent` database to Upgrading and pointed at `UPGRADING.md`.

Dependabot bumps and CI-only changes (#64, #86, #94, #104) are deliberately not listed. The release pipeline entry arrives with #142.

## Install generator

Two gaps a fresh install would have hit:

- `recurring.yml` lacked `aggregate_rollups` (`Upright::Rollups::DailyAggregationJob`) and `advance_maintenances` (`Upright::MaintenanceAdvanceJob`). Added with the schedules the reference deployment uses.
- `database.yml` was split into `primary` and `queue` but never got a `persistent` database, so the health, rollup, incident and maintenance jobs would have run against a database that did not exist (Copilot's finding). The rewrite now produces `primary`, `persistent` and `queue` for development and test, with the persistent `migrations_paths` pointing at the installed gem's `db/persistent_migrate`. It is extracted to `Upright::Generators::DatabaseConfig` with a unit test. The README quick start runs `db:prepare`, which creates and migrates all three.

## UPGRADING.md

A step-by-step guide from 0.3 to 0.4 for existing installs: gem update, persistent database, housekeeping and health jobs, site flags, initializer settings, regenerated recording rules, the admin password fix, Playwright in the app container, the hardened deploy config, and, as a separate opt-in step, the public status page with its jobs and `services.yml`. Ends with checks to run.

## After this and #142 merge

Cut 0.4.0: set `Upright::VERSION`, run `bundle install`, rename the Unreleased heading to `## v0.4.0`, merge, then `rake tag`.
