### PR TITLE
Bump version to 0.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## Unreleased
+## v0.4.0
 
 ### Security
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    upright (0.3.0)
+    upright (0.4.0)
       cgi
       faraday (>= 2.14.3)
       frozen_record
@@ -823,7 +823,7 @@ CHECKSUMS
   tzinfo (2.0.6) sha256=8daf828cc77bcf7d63b0e3bdb6caa47e2272dcfaf4fbfe46f8c3a9df087a829b
   unicode-display_width (3.2.0) sha256=0cdd96b5681a5949cdbc2c55e7b420facae74c4aaf9a9815eee1087cb1853c42
   unicode-emoji (4.2.0) sha256=519e69150f75652e40bf736106cfbc8f0f73aa3fb6a65afe62fefa7f80b0f80f
-  upright (0.3.0)
+  upright (0.4.0)
   uri (1.1.1) sha256=379fa58d27ffb1387eaada68c749d1426738bd0f654d812fcc07e7568f5c57c6
   useragent (0.16.11) sha256=700e6413ad4bb954bb63547fa098dddf7b0ebe75b40cc6f93b8d54255b173844
   validate_url (1.0.15) sha256=72fe164c0713d63a9970bd6700bea948babbfbdcec392f2342b6704042f57451

--- a/lib/upright/version.rb
+++ b/lib/upright/version.rb
@@ -1,5 +1,5 @@
 module Upright
-  VERSION = "0.3.0"
+  VERSION = "0.4.0"
   # Keep in sync with the playwright-ruby-client constraint in upright.gemspec
   PLAYWRIGHT_VERSION = "1.59"
 end


### PR DESCRIPTION
Sets `Upright::VERSION` to 0.4.0, refreshes `Gemfile.lock`, and renames the changelog's Unreleased section to v0.4.0. After merging, `rake tag` pushes `v0.4.0` and the Release workflow publishes it.